### PR TITLE
test trimesh_io: add example coveragerc, conftest, trimesh tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,21 @@
+[report]
+exclude_lines =
+    pragma: no cover
+
+    raise NotImplementedError
+
+    # bad form, but annoying when reported
+    except Exception
+
+    # raw input is low priority and may be removed
+    raw_input
+
+    # __repr__ is usually only important in debugging
+    def __repr__
+
+    # ignore logger messages
+    logger.debug
+    logger.info
+    logger.warning
+    logger.error
+    logger.critical

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,1 @@
+from basic_test import basic_mesh

--- a/test/test_trimesh_io.py
+++ b/test/test_trimesh_io.py
@@ -1,0 +1,82 @@
+import itertools
+import tempfile
+
+import numpy
+import pytest
+
+from meshparty import trimesh_io
+
+
+io_file_exts = ['.h5', '.obj']
+io_overwrite_flags = [True, False]
+io_file_exist = [True, False]
+
+
+def write_meshobject_h5(mesh, filename, overwrite):
+    trimesh_io.write_mesh_h5(filename, mesh.vertices,
+                             mesh.faces, mesh.face_normals,
+                             mesh_edges=mesh.mesh_edges,
+                             overwrite=overwrite)
+
+
+def write_meshobject_other(mesh, filename, overwrite):
+    mesh.write_to_file(filename)
+
+
+@pytest.mark.parametrize(
+    "file_ext,overwrite_flag,file_exist",
+    itertools.product(io_file_exts, io_overwrite_flags, io_file_exist))
+def test_file_read_write(
+        basic_mesh, file_ext, overwrite_flag, file_exist):
+    m = basic_mesh
+    write_func = {
+        '.h5': write_meshobject_h5
+        }.get(
+            file_ext, write_meshobject_other)
+
+    # leave file around
+    with tempfile.NamedTemporaryFile(
+            suffix=file_ext, delete=(not file_exist)) as tf:
+        fname = tf.name
+
+    write_func(m, fname, overwrite_flag)
+
+    # write func fails silently if writing h5 without overwrite.
+    #   obj always overwrites
+    if file_exist and not overwrite_flag and file_ext == '.h5':
+        with pytest.raises(OSError):
+            mvtx, mfaces, mnormals, mmesh_edges = trimesh_io.read_mesh(fname)
+    else:
+        mvtx, mfaces, mnormals, mmesh_edges = trimesh_io.read_mesh(fname)
+        assert numpy.array_equal(mvtx, m.vertices)
+        assert numpy.array_equal(mfaces, m.faces)
+
+        # not sure why, but normals are not being returned in obj
+        if file_ext != '.obj':
+            assert numpy.array_equal(mnormals, m.face_normals)
+            assert numpy.array_equal(mmesh_edges, m.mesh_edges)
+
+
+@pytest.mark.parametrize("indicator_fstring,propstring", [
+    ("meshparty.utils.create_csgraph", "csgraph"),
+    ("meshparty.utils.create_nxgraph", "nxgraph")])
+def test_lazy_mesh_props(basic_mesh, indicator_fstring, propstring, mocker):
+    """
+    indicator_fstring:
+        function mocked indicating lazy property is being evaluated
+    propstring:
+        lazily evaluated property being tested against
+    """
+    m = basic_mesh
+
+    mocked_f = mocker.patch(indicator_fstring)
+
+    mocked_f.assert_not_called()
+
+    firstp = getattr(m, propstring)
+    mocked_f.assert_called_once()
+
+    secondp = getattr(m, propstring)
+    mocked_f.assert_called_once()
+
+    assert firstp is secondp

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-cov
 pytest-runner
 pytest-xdist
+pytest-mock


### PR DESCRIPTION
adds a little test/coverage infrastructure stuff and tests against lazy properties in the mesh class.

The reading/writing files test bakes in some quirks of the current version of the module, but it's probably outside the scope of this party to change functionality (and this way when that change does happen, it can be test driven). 