### PR TITLE
fix_mesh tests and fix broken pymeshfix interface

### DIFF
--- a/meshparty/trimesh_io.py
+++ b/meshparty/trimesh_io.py
@@ -148,7 +148,7 @@ def _download_meshes_thread(args):
             print('file exists {}'.format(target_file))
             continue
         print('file does not exist {}'.format(target_file))
-       
+
         try:
             cv_mesh = cv.mesh.get(seg_id,
                                   remove_duplicate_vertices=remove_duplicate_vertices)
@@ -392,11 +392,14 @@ class Mesh(trimesh.Trimesh):
         """
         if self.body_count > 1:
             tin = _meshfix.PyTMesh(verbose)
-            tin.LoadArray(self.vertices, self.faces)
-            tin.RemoveSmallestComponents()
+            # tin.LoadArray(self.vertices, self.faces)
+            tin.load_array(self.vertices, self.faces)
+            tin.remove_smallest_components()
+            # tin.RemoveSmallestComponents()
 
             # Check if volume is 0 after isolated components have been removed
-            self.vertices, self.faces = tin.ReturnArrays()
+            # self.vertices, self.faces = tin.ReturnArrays()
+            self.vertices, self.faces = tin.return_arrays()
 
             self.fix_normals()
 
@@ -407,9 +410,11 @@ class Mesh(trimesh.Trimesh):
             wiggle = np.random.randn(self.n_vertices * 3).reshape(-1, 3) * 10
             self.vertices += wiggle
 
-        self.vertices, self.faces = _meshfix.CleanFromVF(self.vertices,
-                                                         self.faces,
-                                                         verbose=verbose)
+        # self.vertices, self.faces = _meshfix.CleanFromVF(self.vertices,
+        #                                                  self.faces,
+        #                                                  verbose=verbose)
+        self.vertices, self.faces = _meshfix.clean_from_arrays(
+            self.vertices, self.faces, verbose=verbose)
 
         self.fix_normals()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ multiwrapper
 trimesh
 -e git+https://github.com/seung-lab/cloud-volume.git@graphene#egg=cloud-volume
 pyassimp
-pymeshfix
+pymeshfix>=0.12.3
 vtk
 pcst_fast

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,1 +1,2 @@
-from basic_test import basic_mesh
+from basic_test import (  # noqa: F401
+    basic_mesh, full_cell_mesh, basic_cube_mesh)

--- a/test/test_trimesh_io.py
+++ b/test/test_trimesh_io.py
@@ -6,6 +6,8 @@ import pytest
 
 from meshparty import trimesh_io
 
+from basic_test import build_basic_cube_mesh
+
 
 io_file_exts = ['.h5', '.obj']
 io_overwrite_flags = [True, False]
@@ -80,3 +82,22 @@ def test_lazy_mesh_props(basic_mesh, indicator_fstring, propstring, mocker):
     mocked_f.assert_called_once()
 
     assert firstp is secondp
+
+
+@pytest.fixture(scope='function')
+def basic_cube_mesh_fscope():
+    with build_basic_cube_mesh() as r:
+        yield r
+
+
+@pytest.mark.parametrize("wiggle", [True, False])
+def test_fix_mesh(basic_cube_mesh_fscope, basic_cube_mesh, wiggle):
+    basic_cube_mesh_fscope.fix_mesh(wiggle_vertices=wiggle)
+    if wiggle:
+        assert not numpy.array_equal(
+            basic_cube_mesh.vertices,
+            basic_cube_mesh_fscope.vertices)
+    else:
+        assert numpy.array_equal(
+            basic_cube_mesh.vertices,
+            basic_cube_mesh_fscope.vertices)


### PR DESCRIPTION
This adds a simple test for fix_mesh as well as a cube fixture and some infrastructure to make fixture scopes more general with a context manager.

Important note here -- there was a breaking change in pymeshfix where (as the commit explains) the cython methods moved to a pep8 format and away from PascalCase.  I can make it more backward-compatible if this is a pain.