### PR TITLE
remove pyassimp dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ networkx
 multiwrapper
 trimesh
 -e git+https://github.com/seung-lab/cloud-volume.git@graphene#egg=cloud-volume
-pyassimp
 pymeshfix>=0.12.3
 pykdtree
 vtk


### PR DESCRIPTION
pyassimp is not used in this module (as mesh io is handled for specific file types in trimesh_io) and is not actually a requirement of this or trimesh.  Trimesh's use of this is as a default loader for various formats, but even it prefers cyassimp when available.

This gets rid of the need to install libassimp.