### PR TITLE
Vtk camera fix

### DIFF
--- a/meshparty/trimesh_vtk.py
+++ b/meshparty/trimesh_vtk.py
@@ -277,9 +277,7 @@ def vtk_super_basic(actors, camera=None, do_save=False, folder=".", back_color=(
     renWin = vtk.vtkRenderWindow()
     renWin.AddRenderer(ren)
     renWin.SetSize(VIDEO_WIDTH, VIDEO_HEIGHT)
-    if camera is not None:
-        ren.SetActiveCamera(camera)
-        ren.ResetCameraClippingRange()
+
 
     ren.SetBackground(*back_color)
     # create a renderwindowinteractor
@@ -293,6 +291,10 @@ def vtk_super_basic(actors, camera=None, do_save=False, folder=".", back_color=(
     # render
     if camera is None:
         ren.ResetCamera()
+    else:
+        ren.SetActiveCamera(camera)
+        ren.ResetCameraClippingRange()
+        camera.ViewingRaysModified()
     renWin.Render()
 
     trackCamera = vtk.vtkInteractorStyleTrackballCamera()

--- a/meshparty/trimesh_vtk.py
+++ b/meshparty/trimesh_vtk.py
@@ -279,6 +279,7 @@ def vtk_super_basic(actors, camera=None, do_save=False, folder=".", back_color=(
     renWin.SetSize(VIDEO_WIDTH, VIDEO_HEIGHT)
     if camera is not None:
         ren.SetActiveCamera(camera)
+        ren.ResetCameraClippingRange()
 
     ren.SetBackground(*back_color)
     # create a renderwindowinteractor


### PR DESCRIPTION
I have fixed the bug that specifying the camera requires you to interact with the window before it displays, and added features that allow you to specify cameras from quaterion orientations and neuroglancer state dictionaries. 