### PR TITLE
moving assert to allow for no cv_path but disk cached meshes

### DIFF
--- a/meshparty/trimesh_io.py
+++ b/meshparty/trimesh_io.py
@@ -254,8 +254,6 @@ class MeshMeta(object):
             if True: recalculate large components
         :return: Mesh
         """
-        assert filename is not None or \
-            (seg_id is not None and self.cv is not None)
 
         if filename is not None:
             if filename not in self._mesh_cache:
@@ -282,7 +280,7 @@ class MeshMeta(object):
                                      merge_large_components=merge_large_components,
                                      overwrite_merge_large_components=overwrite_merge_large_components)
                     return mesh
-
+            assert (seg_id is not None and self.cv is not None)
             if seg_id not in self._mesh_cache or force_download is True:
                 cv_mesh = self.cv.mesh.get(seg_id, remove_duplicate_vertices=remove_duplicate_vertices)
                 faces = np.array(cv_mesh["faces"])


### PR DESCRIPTION
this will allow for the assert to only kick in when its relevant, thus allowing people to use disk cache meshes without access to the cloudvolume server (useful for friday harbor or when you aren't at a location with an authorized IP).