### PR TITLE
Resolution adjustment

### DIFF
--- a/meshparty/skeleton.py
+++ b/meshparty/skeleton.py
@@ -414,6 +414,7 @@ class Skeleton:
         self._segments = None
         self._segment_map = None
 
+
     def _create_csgraph(self,
                         directed=True,
                         euclidean_weight=True):
@@ -490,6 +491,22 @@ class Skeleton:
                 segment_map[segment] = seg_ind
                 seg_ind += 1
         return segments, segment_map.astype(int)
+
+    def write_to_h5(self, filename, overwrite=True):
+        """Write the skeleton to an HDF5 file. Note that this is done in the original dimensons, not the scaled dimensions.
+        
+        Parameters
+        ----------
+        filename : str 
+            Filename to save file
+        overwrite : bool, optional
+            Flag to specify whether to overwrite existing files, by default True
+        """
+        existing_voxel_scaling = self.voxel_scaling
+        self.voxel_scaling = None
+        skeleton_io.write_skeleton_h5(self, filename, overwrite=overwrite)
+        self.voxel_scaling = existing_voxel_scaling
+
 
     def export_to_swc(self, filename, node_labels=None, radius=None, header=None, xyz_scaling=1000):
         '''

--- a/meshparty/trimesh_io.py
+++ b/meshparty/trimesh_io.py
@@ -558,13 +558,12 @@ class MeshMeta(object):
                 mesh_data = read_mesh(filename)
                 vertices, faces, normals, link_edges, node_mask = mesh_data
                 mesh = Mesh(vertices=vertices, faces=faces, normals=normals,
-                            link_edges=link_edges, node_mask=node_mask, voxel_scaling=voxel_scaling)
+                            link_edges=link_edges, node_mask=node_mask)
 
                 if cache_mesh and len(self._mesh_cache) < self.cache_size:
                     self._mesh_cache[filename] = mesh
             else:
                 mesh = self._mesh_cache[filename]
-                mesh.voxel_scaling = voxel_scaling
 
             if self.disk_cache_path is not None and \
                     overwrite_merge_large_components:
@@ -592,12 +591,10 @@ class MeshMeta(object):
                     faces = faces.reshape(-1, 3)
 
                 mesh = Mesh(vertices=cv_mesh.vertices,
-                            faces=faces,
-                            voxel_scaling=voxel_scaling)
+                            faces=faces)
 
                 if cache_mesh and len(self._mesh_cache) < self.cache_size:
                     self._mesh_cache[seg_id] = mesh
-                    mesh.voxel_scaling = voxel_scaling
 
                 if self.disk_cache_path is not None:
                     write_mesh_h5(self._filename(seg_id), mesh.vertices,
@@ -606,8 +603,9 @@ class MeshMeta(object):
                                   overwrite=force_download)
             else:
                 mesh = self._mesh_cache[seg_id]
-                mesh.voxel_scaling = voxel_scaling
 
+        mesh.voxel_scaling = voxel_scaling
+        
         if (merge_large_components and (len(mesh.link_edges)==0)) or \
                         overwrite_merge_large_components:
                     mesh.merge_large_components()

--- a/meshparty/trimesh_io.py
+++ b/meshparty/trimesh_io.py
@@ -598,6 +598,8 @@ class MeshMeta(object):
 
                 if self.disk_cache_path is not None:
                     mesh.write_to_file(self._filename(seg_id), overwrite=force_download)
+            else:
+                mesh = self._mesh_cache[seg_id]
 
         mesh.voxel_scaling = voxel_scaling
 

--- a/meshparty/trimesh_io.py
+++ b/meshparty/trimesh_io.py
@@ -1315,7 +1315,7 @@ class Mesh(trimesh.Trimesh):
         else:
             raise ValueError('Incompatible shape. Must be either original length or current length of vertices.')
 
-        new_mesh = Mesh(self.vertices,
+        new_mesh = Mesh(self.vertices * self.inverse_voxel_scaling,
                         self.faces,
                         node_mask=joint_mask,
                         unmasked_size=self.unmasked_size,

--- a/meshparty/trimesh_io.py
+++ b/meshparty/trimesh_io.py
@@ -26,9 +26,33 @@ from tqdm import trange
 
 from meshparty import utils, trimesh_repair
 
+try:
+    from annotationframeworkclient import infoservice
+    allow_framework_client = True
+except ImportError:
+    logging.warning("Need to pip install annotationframeworkclient to use dataset_name parameters")
+    allow_framework_client = False
+
 class EmptyMaskException(Exception):
     """Raised when applying a mask that has all zeros"""
     pass
+
+def _get_cv_path_from_info(dataset_name, server_address=None, segmentation_type='graphene'):
+    """Get the cloudvolume path from a dataset name. Segmentation type should be
+       either `graphene` or `flat`.
+    """
+    if allow_framework_client is False:
+        logging.warning("Need to pip install annotationframeworkclient to use dataset_name parameters")
+        return None
+    
+    info = infoservice.InfoServiceClient(dataset_name=dataset_name, server_address=server_address)
+    if segmentation_type == 'graphene':
+        cv_path = info.graphene_source(format_for='cloudvolume')
+    elif segmentation_type == 'flat':
+        cv_path = info.flat_segmentation_source(format_for='cloudvolume')
+    else:
+        cv_path = None
+    return cv_path
 
 def read_mesh_h5(filename):
     """Reads a mesh's vertices, faces and normals from an hdf5 file
@@ -404,22 +428,32 @@ class MeshMeta(object):
             set to zero to use less memory but read from disk cache
         cv_path: str
             path to pass to cloudvolume.CloudVolume
+        dataset_name: str
+            Dataset name to use to get cloudvolume path via infoservice
+        server_address: str
+            Server address for the infoservice. Uses a default value if None.
+        segmentation_type: 'graphene' or 'flat'
+            Selects which type of segmentation to use. Graphene is for proofreadable segmentations, flat is for static segmentations.
         disk_cache_path: str
             meshes are dumped to this directory => should be equal to target_dir
             in download_meshes (default None will not cache meshes)
         map_gs_to_https: bool
             whether to change gs paths to https paths, via cloudvolume's use_https option
+        voxel_scaling: 3x1 numeric
+            Allows a post-facto multiplicative scaling of vertex locations. These values are NOT saved, just used for analysis and visualization.
         """
-
-    def __init__(self, cache_size=400, cv_path=None, disk_cache_path=None,
-                 map_gs_to_https=True):
+    def __init__(self, cache_size=400, cv_path=None, dataset_name=None, server_address=None, segmentation_type='graphene',
+                 disk_cache_path=None, map_gs_to_https=True, voxel_scaling=None):
 
         self._mesh_cache = {}
         self._cache_size = cache_size
+        if cv_path is None and dataset_name is not None:
+            cv_path = _get_cv_path_from_info(dataset_name=dataset_name, server_address=server_address, segmentation_type=segmentation_type)
         self._cv_path = cv_path
         self._cv = None
         self._map_gs_to_https = map_gs_to_https
         self._disk_cache_path = disk_cache_path
+        self._voxel_scaling = voxel_scaling
 
         if self.disk_cache_path is not None:
             if not os.path.exists(self.disk_cache_path):
@@ -449,6 +483,10 @@ class MeshMeta(object):
 
         return self._cv
 
+    @property
+    def voxel_scaling(self):
+        return self._voxel_scaling
+
     def _filename(self, seg_id):
         """ a method to define what path this seg_id will or is saved to
         
@@ -467,7 +505,8 @@ class MeshMeta(object):
              stitch_mesh_chunks=True,
              overwrite_merge_large_components=False,
              remove_duplicate_vertices=False,
-             force_download=False):
+             force_download=False,
+             voxel_scaling=None):
         """ Loads mesh either from cache, disk or google storage
 
         Note, if the mesh is in a cache (memory or disk)
@@ -497,6 +536,8 @@ class MeshMeta(object):
             whether to bluntly removed duplicate vertices (default False)
         force_download: bool
             whether to force the mesh to be redownloaded from cloudvolume
+        voxel_scaling: 3x1 numeric
+            Allows a post-facto multiplicative scaling of vertex locations. These values are NOT saved, just used for analysis and visualization.
 
         Returns
         -------
@@ -515,12 +556,13 @@ class MeshMeta(object):
                 mesh_data = read_mesh(filename)
                 vertices, faces, normals, link_edges, node_mask = mesh_data
                 mesh = Mesh(vertices=vertices, faces=faces, normals=normals,
-                                        link_edges=link_edges, node_mask=node_mask)
+                            link_edges=link_edges, node_mask=node_mask, voxel_scaling=voxel_scaling)
 
                 if cache_mesh and len(self._mesh_cache) < self.cache_size:
                     self._mesh_cache[filename] = mesh
             else:
                 mesh = self._mesh_cache[filename]
+                mesh._voxel_scaling = voxel_scaling
 
             if self.disk_cache_path is not None and \
                     overwrite_merge_large_components:
@@ -533,7 +575,8 @@ class MeshMeta(object):
                     mesh = self.mesh(filename=self._filename(seg_id),
                                      cache_mesh=cache_mesh,
                                      merge_large_components=merge_large_components,
-                                     overwrite_merge_large_components=overwrite_merge_large_components)
+                                     overwrite_merge_large_components=overwrite_merge_large_components,
+                                     voxel_scaling=voxel_scaling)
                     return mesh
             assert (seg_id is not None and self.cv is not None)
             if seg_id not in self._mesh_cache or force_download is True:
@@ -547,7 +590,8 @@ class MeshMeta(object):
                     faces = faces.reshape(-1, 3)
 
                 mesh = Mesh(vertices=cv_mesh.vertices,
-                            faces=faces)
+                            faces=faces,
+                            voxel_scaling=voxel_scaling)
 
                 if cache_mesh and len(self._mesh_cache) < self.cache_size:
                     self._mesh_cache[seg_id] = mesh
@@ -559,7 +603,8 @@ class MeshMeta(object):
                                   overwrite=force_download)
             else:
                 mesh = self._mesh_cache[seg_id]
-    
+                mesh._voxel_scaling = voxel_scaling
+
         if (merge_large_components and (len(mesh.link_edges)==0)) or \
                         overwrite_merge_large_components:
                     mesh.merge_large_components()
@@ -591,8 +636,7 @@ class Mesh(trimesh.Trimesh):
         all the other keyword args you want to pass to :class:`trimesh.Trimesh`
 
     """
-
-    def __init__(self, *args, node_mask=None, unmasked_size=None, apply_mask=False, link_edges=None, **kwargs):
+    def __init__(self, *args, node_mask=None, unmasked_size=None, apply_mask=False, link_edges=None, voxel_scaling=None, **kwargs):
         if 'vertices' in kwargs:
             vertices_all = kwargs.pop('vertices')
         else:
@@ -603,6 +647,11 @@ class Mesh(trimesh.Trimesh):
         else:
             # If faces are in args, vertices must also have been in args
             faces_all = args[1]
+
+        self._voxel_scaling = voxel_scaling
+        if self._voxel_scaling is not None:
+            vertices_all = vertices_all * self._voxel_scaling
+            self._inverse_voxel_scaling = 1/self._voxel_scaling
 
         if unmasked_size is None:
             if node_mask is not None:
@@ -656,7 +705,19 @@ class Mesh(trimesh.Trimesh):
             self.link_edges = link_edges
 
         self._index_map = None
-        
+
+    # Helper class for handling scaling issues
+    class ScalingManagement(object):
+        @classmethod
+        def original_scaling(_, func):
+            def wrapper(*args, **kwargs):
+                if self._voxel_scaling is not None:
+                    self.vertices = self.vertices * self._inverse_voxel_scaling
+                func(*args, **kwargs)
+                if self._voxel_scaling is not None:
+                    self.vertices = self.vertices * self._voxel_scaling
+            return wrapper
+
     @property
     def link_edges(self):
         """numpy.array : a Kx2 set of textra edges you want to store in the mesh graph,
@@ -995,7 +1056,7 @@ class Mesh(trimesh.Trimesh):
 
         return utils.filter_shapes(node_ids, self.graph_edges)
 
-
+    @ScalingManagement.original_scaling
     def add_link_edges(self, seg_id, dataset_name, close_map_distance=300,
                         server_address="https://www.dynamicannotationframework.com"):
         """ add a set of link edges to this mesh from a PyChunkedGraph endpoint
@@ -1017,8 +1078,8 @@ class Mesh(trimesh.Trimesh):
         link_edges = trimesh_repair.get_link_edges(self, seg_id, dataset_name,
                                                    close_map_distance = close_map_distance,
                                                    server_address=server_address)
-        self.link_edges = np.vstack([self.link_edges, link_edges])
 
+        self.link_edges = np.vstack([self.link_edges, link_edges])
 
                         
     def get_local_meshes(self, n_points, max_dist=np.inf, center_node_ids=None,
@@ -1319,6 +1380,7 @@ class Mesh(trimesh.Trimesh):
 
         return new_shape[keep_rows]
 
+    @ScalingManagement.original_scaling
     def write_to_file(self, filename):
         """ Exports the mesh to any format supported by trimesh
 
@@ -1351,6 +1413,7 @@ class Mesh(trimesh.Trimesh):
             for ii, index in enumerate(self.indices_unmasked):
                 self._index_map[index] = ii
         return self._index_map
+
 
 class MaskedMesh(Mesh):
     def __init__(self, *args,  **kwargs):

--- a/meshparty/trimesh_io.py
+++ b/meshparty/trimesh_io.py
@@ -743,7 +743,7 @@ class Mesh(trimesh.Trimesh):
             Sets the new xyz scale relative to the resolution from the mesh source
         """
         if self._voxel_scaling is not None:
-            vertices_all = vertices_all * self.inverse_voxel_scaling
+            self.vertices = self.vertices * self.inverse_voxel_scaling
         
         if new_scaling is not None:
             self._voxel_scaling = np.array(new_scaling).reshape(3)

--- a/meshparty/trimesh_repair.py
+++ b/meshparty/trimesh_repair.py
@@ -9,7 +9,7 @@ import logging
 try:
     from annotationframeworkclient import chunkedgraph
 except ImportError:
-    logging.warning("Need to pip install annotationframework client to repair mesh with pychunkedgraph")
+    logging.warning("Need to pip install annotationframeworkclient to repair mesh with pychunkedgraph")
 
 
 def np_shared_rows(A,B):

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -287,3 +287,23 @@ def test_local_mesh(full_cell_mesh):
     assert(len(local_mesh.vertices)==500)
     local_view = full_cell_mesh.get_local_view(n_points=500, max_dist=5000, center_node_id=vertex)
     assert(len(local_view[0][0])==500)
+
+
+def test_mesh_rescale(full_cell_mesh):
+    original_area = full_cell_mesh.area
+
+    full_cell_mesh.voxel_scaling = [2,2,1]
+    new_area = full_cell_mesh.area
+    assert np.isclose(51309567968.120735, new_area, atol=1)
+
+    full_cell_mesh.voxel_scaling = None
+    restored_area = full_cell_mesh.area
+    assert original_area == restored_area
+
+def test_mesh_meta_rescale(cv_path, full_cell_mesh_id, tmpdir):
+    mm = trimesh_io.MeshMeta(cv_path=cv_path,
+                            cache_size=0,
+                            disk_cache_path=os.path.join(tmpdir,'mesh_cache'),
+                            voxel_scaling=[2,2,1])
+    mmesh = mm.mesh(seg_id=full_cell_mesh_id)
+    assert np.isclose(51309567968.120735, mmesh.area, atol=1) 

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -271,8 +271,10 @@ def test_link_edges(full_cell_mesh, full_cell_merge_log, full_cell_soma_pt, monk
     monkeypatch.setattr(trimesh_io.trimesh_repair.chunkedgraph,
                         'ChunkedGraphClient',
                         MyChunkedGraph)
-
+    
+    full_cell_mesh.voxel_scaling = [10, 10, 10]
     full_cell_mesh.add_link_edges('test', 5)
+    full_cell_mesh.voxel_scaling = None
 
     out=mesh_filters.filter_largest_component(full_cell_mesh)
     mesh_filter = full_cell_mesh.apply_mask(out)

--- a/test/skeleton_io_test.py
+++ b/test/skeleton_io_test.py
@@ -101,3 +101,17 @@ def test_skeleton_h5_read(full_cell_skeleton):
     print(full_cell_skeleton.root)
     assert type(full_cell_skeleton) is skeleton.Skeleton
     assert full_cell_skeleton.root == 42591
+
+
+def test_skeleton_rescale(full_cell_skeleton):
+    end_points = full_cell_skeleton.end_points
+    orig_dist = full_cell_skeleton.distance_to_root[end_points[10]]
+
+    full_cell_skeleton.voxel_scaling = [2,2,1]
+    new_dist = full_cell_skeleton.distance_to_root[end_points[10]]
+    assert not np.isclose(new_dist, orig_dist)
+    assert np.isclose(new_dist, 251222.009984970, atol=0.001)
+
+    full_cell_skeleton.voxel_scaling = None 
+    reset_dist = full_cell_skeleton.distance_to_root[end_points[10]]
+    assert np.isclose(orig_dist, reset_dist)


### PR DESCRIPTION
This branch adds a voxel_scaling parameter to meshes and skeletons that allows a dynamic and reversible rescaling of mesh vertex locations. This should only be used for analysis to avoid multiple sources of truth for the same data. This initial version only handles multiplicative scaling, although the framework should permit other types of transformations without much trouble.

Basic use:

1) From a MeshMeta with a default voxel scaling to apply to all meshes it loads:
```python

mm = trimesh_io.MeshMeta( ... , voxel_scaling=[0.895, 0.895, 1])
mesh = mm.mesh(seg_id=seg_id)
# This mesh comes in with a voxel scaling as given to the MeshMeta
```

2) From an existing mesh:
```python
new_voxel_scaling = [0.5, 0.5, 1]
mesh.voxel_scaling = new_voxel_scaling
```

3) To reset to the original dimensions:
```python
mesh.voxel_scaling = None
```

4) For skeletons:
```python
new_voxel_scaling = [0.5, 0.5, 1]
sk.voxel_scaling = new_voxel_scaling
```

Note that for some actions, one does not want scaled vertex values. These include saving the mesh to disk and adding link edges. There are internal controls that handle this, but they are only invoked if the action is called from the mesh itself. Thus:
* For adding link edges:
```python
# This approach handles rescaled vertices:
mesh.add_link_edges( ... )

# This approach does NOT know to rescale vertices:
trimesh_repair.get_link_edges(mesh, ... )
```

* For saving:
```python
# This approach handles rescaled vertices:
mesh.write_to_file( ... )

# This approach does NOT know to rescale vertices:
trimesh_io.write_mesh_h5(mesh.vertices, mesh.faces, ... )
```

* Similarly, for skeletons, I've added a `sk.write_to_h5` command that can respect the internal voxel_scaling parameter.
