### PR TITLE
Bytes compatible saving csm

### DIFF
--- a/meshparty/meshwork/meshwork.py
+++ b/meshparty/meshwork/meshwork.py
@@ -234,7 +234,7 @@ class AnchoredAnnotation(object):
             data = pd.DataFrame({index_column: data})
 
         self._name = name
-        self._data = data.reset_index()
+        self._data = data.reset_index(drop=True)
         self._original_columns = data.columns
         self._max_distance = max_distance
 
@@ -257,7 +257,7 @@ class AnchoredAnnotation(object):
                 self._data[self._index_column_base] = mesh.map_indices_to_unmasked(
                     data[index_column]
                 )
-                self._data[self._index_column_filt] = data[index_column]
+                self._data[self._index_column_filt] = data[index_column].values
 
         if self._defined_index:
             self._orig_col_plus_index = list(self._original_columns)
@@ -308,6 +308,10 @@ class AnchoredAnnotation(object):
     @property
     def index_column(self):
         return self._index_column_filt
+
+    @property
+    def index_column_original(self):
+        return self._index_column_base
 
     @property
     def _is_valid(self):

--- a/meshparty/meshwork/meshwork.py
+++ b/meshparty/meshwork/meshwork.py
@@ -1457,8 +1457,9 @@ class Meshwork(object):
     ##########
     # Saving #
     ##########
-
-    def save_meshwork(self, filename, overwrite=False):
+    def save_meshwork(
+        self, filename, overwrite=False, version=meshwork_io.LATEST_VERSION
+    ):
         """Save meshwork to hdf5 file.
 
         Parameters
@@ -1468,7 +1469,7 @@ class Meshwork(object):
         overwrite : bool, optional
             If True, overwrites an existing file. Default is False.
         """
-        meshwork_io._save_meshwork(filename, self, overwrite=overwrite)
+        meshwork_io._save_meshwork(filename, self, overwrite=overwrite, version=version)
 
 
 def load_meshwork(filename):

--- a/meshparty/meshwork/meshwork.py
+++ b/meshparty/meshwork/meshwork.py
@@ -810,6 +810,7 @@ class Meshwork(object):
                 shape_function=shape_function,
                 collapse_function=collapse_function,
                 collapse_params=collapse_params,
+                meta={"root_id": self.seg_id},
             )
             self._reset_indices()
         else:

--- a/meshparty/meshwork/meshwork_io.py
+++ b/meshparty/meshwork/meshwork_io.py
@@ -195,7 +195,8 @@ def save_meshwork_annotations(filename, mw, version=LATEST_VERSION):
             dset.attrs["max_distance"] = anno._max_distance
             dset.attrs["defined_index"] = int(anno._defined_index)
             if anno._defined_index is True:
-                dset.attrs["index_column"] = anno._index_column_base
+                dset.attrs["index_column"] = anno.index_column_original
+            
         anno_save_function[version](
             annos[table_name].data_original, table_name, filename
         )

--- a/meshparty/meshwork/meshwork_io.py
+++ b/meshparty/meshwork/meshwork_io.py
@@ -237,9 +237,8 @@ def _save_meshwork(filename, mw, overwrite=False, version=LATEST_VERSION):
                 raise FileExistsError()
             else:
                 print(f"\tDeleting existing data in {filename}...")
-                with h5py.File(filename, "r+") as f:
-                    for d in f.keys():
-                        del f[d]
+                with h5py.File(filename, "w") as f:
+                    pass
 
     save_meshwork_metadata(filename, mw, version=version)
     save_meshwork_mesh(filename, mw, version=version)

--- a/meshparty/meshwork/meshwork_io.py
+++ b/meshparty/meshwork/meshwork_io.py
@@ -3,16 +3,21 @@ from ..skeleton import Skeleton
 from ..trimesh_io import Mesh
 import h5py
 import os
-from tqdm import tqdm
+import orjson
 import pandas as pd
 import warnings
+import numpy as np
 
 warnings.simplefilter(action="ignore", category=pd.errors.PerformanceWarning)
 
+NULL_VERSION = 1
+LATEST_VERSION = 2
 
-def save_meshwork_metadata(filename, mw):
+
+def save_meshwork_metadata(filename, mw, version=LATEST_VERSION):
     with h5py.File(filename, "a") as f:
         f.attrs["voxel_resolution"] = mw.anno.voxel_resolution
+        f.attrs["version"] = version
         if mw.seg_id is not None:
             f.attrs["seg_id"] = mw.seg_id
 
@@ -22,10 +27,11 @@ def load_meshwork_metadata(filename):
     with h5py.File(filename, "r") as f:
         meta["seg_id"] = f.attrs.get("seg_id", None)
         meta["voxel_resolution"] = f.attrs.get("voxel_resolution", None)
+        meta["version"] = f.attrs.get("version", NULL_VERSION)
     return meta
 
 
-def save_meshwork_mesh(filename, mw):
+def save_meshwork_mesh(filename, mw, version=LATEST_VERSION):
     node_mask = mw.mesh_mask
     if mw._original_mesh_data is not None:
         vs, fs, es, nm, vxsc = decompress_mesh_data(*mw._original_mesh_data)
@@ -35,11 +41,9 @@ def save_meshwork_mesh(filename, mw):
 
     with h5py.File(filename, "a") as f:
         f.create_group("mesh")
-        f.create_dataset("mesh/vertices", data=mesh.vertices,
-                         compression="gzip")
+        f.create_dataset("mesh/vertices", data=mesh.vertices, compression="gzip")
         f.create_dataset("mesh/faces", data=mesh.faces, compression="gzip")
-        f.create_dataset("mesh/node_mask",
-                         data=mesh.node_mask, compression="gzip")
+        f.create_dataset("mesh/node_mask", data=mesh.node_mask, compression="gzip")
         if mesh.voxel_scaling is not None:
             f["mesh"].attrs["voxel_scaling"] = mesh.voxel_scaling
         if mesh.link_edges is not None:
@@ -49,7 +53,7 @@ def save_meshwork_mesh(filename, mw):
         f.create_dataset("mesh/mesh_mask", data=node_mask, compression="gzip")
 
 
-def load_meshwork_mesh(filename):
+def load_meshwork_mesh(filename, version=NULL_VERSION):
     with h5py.File(filename, "r") as f:
         verts = f["mesh/vertices"][()]
         faces = f["mesh/faces"][()]
@@ -76,32 +80,30 @@ def load_meshwork_mesh(filename):
     )
 
 
-def save_meshwork_skeleton(filename, mw):
+def save_meshwork_skeleton(filename, mw, version=LATEST_VERSION):
     if mw.skeleton is None:
         return
 
     sk = mw.skeleton.reset_mask()
     with h5py.File(filename, "a") as f:
         f.create_group("skeleton")
-        f.create_dataset("skeleton/vertices",
-                         data=sk.vertices, compression="gzip")
+        f.create_dataset("skeleton/vertices", data=sk.vertices, compression="gzip")
         f.create_dataset("skeleton/edges", data=sk.edges, compression="gzip")
         f.create_dataset("skeleton/root", data=sk.root)
         f.create_dataset(
             "skeleton/mesh_to_skel_map", data=sk.mesh_to_skel_map, compression="gzip"
         )
         if sk.radius is not None:
-            f.create_dataset("skeleton/radius",
-                             data=sk.radius, compression="gzip")
+            f.create_dataset("skeleton/radius", data=sk.radius, compression="gzip")
         if sk.mesh_index is not None:
             f.create_dataset(
                 "skeleton/mesh_index", data=sk.mesh_index, compression="gzip"
             )
         if sk.voxel_scaling is not None:
-            f["skeleton"].attrs["voxel_scaling"] = mesh.voxel_scaling
+            f["skeleton"].attrs["voxel_scaling"] = sk.voxel_scaling
 
 
-def load_meshwork_skeleton(filename):
+def load_meshwork_skeleton(filename, version=NULL_VERSION):
     with h5py.File(filename, "r") as f:
         if "skeleton" not in f:
             return None
@@ -131,8 +133,44 @@ def load_meshwork_skeleton(filename):
         )
 
 
-def save_meshwork_annotations(filename, mw):
+def _save_dataframe_generic(df, table_name, filename):
+    key = f"annotations/{table_name}/data"
+    dat = orjson.dumps(
+        df.to_dict(), option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY
+    )
+    with h5py.File(filename, "a") as f:
+        f.create_dataset(key, data=np.string_(dat))
+    pass
+
+
+def _load_dataframe_generic(filename, table_name):
+    key = f"annotations/{table_name}/data"
+    with h5py.File(filename, "r") as f:
+        dat = f[key][()].tobytes()
+        df = pd.DataFrame.from_records(orjson.loads(dat))
+    return df
+
+
+def _save_dataframe_pandas(data, table_name, filename):
+    data.to_hdf(
+        filename, f"annotations/{table_name}/data", complib="blosc", complevel=5
+    )
+    pass
+
+
+def _load_dataframe_pandas(filename, table_name):
+    return pd.read_hdf(filename, f"annotations/{table_name}/data")
+
+
+anno_save_function = {1: _save_dataframe_pandas, 2: _save_dataframe_generic}
+anno_load_function = {1: _load_dataframe_pandas, 2: _load_dataframe_generic}
+
+
+def save_meshwork_annotations(filename, mw, version=LATEST_VERSION):
     annos = mw.anno
+    if version not in anno_save_function:
+        raise ValueError(f"Version must be one of {list(anno_save_function)}")
+
     for table_name in annos.table_names:
         with h5py.File(filename, "a") as f:
             dset = f.create_group(f"annotations/{table_name}")
@@ -144,12 +182,12 @@ def save_meshwork_annotations(filename, mw):
             dset.attrs["defined_index"] = int(anno._defined_index)
             if anno._defined_index is True:
                 dset.attrs["index_column"] = anno._index_column_base
-        annos[table_name].data_original.to_hdf(
-            filename, f"annotations/{table_name}/data", complib="blosc", complevel=5
+        anno_save_function[version](
+            annos[table_name].data_original, table_name, filename
         )
 
 
-def load_meshwork_annotations(filename):
+def load_meshwork_annotations(filename, version=NULL_VERSION):
 
     with h5py.File(filename, "r") as f:
         if "annotations" not in f:
@@ -159,8 +197,10 @@ def load_meshwork_annotations(filename):
     annotation_dfs = {}
     for table_name in table_names:
         annotation_dfs[table_name] = {}
-        df = pd.read_hdf(filename, f"annotations/{table_name}/data")
-        annotation_dfs[table_name]["data"] = df
+        # df = pd.read_hdf(filename, f"annotations/{table_name}/data")
+        annotation_dfs[table_name]["data"] = anno_load_function[version](
+            filename, table_name
+        )
         with h5py.File(filename, "r") as f:
             dset = f[f"annotations/{table_name}"]
             annotation_dfs[table_name]["anchor_to_mesh"] = bool(
@@ -169,8 +209,7 @@ def load_meshwork_annotations(filename):
             annotation_dfs[table_name]["point_column"] = dset.attrs.get(
                 "point_column", None
             )
-            annotation_dfs[table_name]["max_distance"] = dset.attrs.get(
-                "max_distance")
+            annotation_dfs[table_name]["max_distance"] = dset.attrs.get("max_distance")
             if bool(dset.attrs.get("defined_index", False)):
                 annotation_dfs[table_name]["index_column"] = dset.attrs.get(
                     "index_column", None
@@ -178,25 +217,27 @@ def load_meshwork_annotations(filename):
     return annotation_dfs
 
 
-def _save_meshwork(filename, mw, overwrite=False):
-    if os.path.exists(filename):
-        if overwrite is False:
-            raise FileExistsError()
-        else:
-            print(f"\tDeleting existing data in {filename}...")
-            with h5py.File(filename, "r+") as f:
-                for d in f.keys():
-                    del f[d]
+def _save_meshwork(filename, mw, overwrite=False, version=LATEST_VERSION):
+    if isinstance(filename, str):
+        if os.path.exists(filename):
+            if overwrite is False:
+                raise FileExistsError()
+            else:
+                print(f"\tDeleting existing data in {filename}...")
+                with h5py.File(filename, "r+") as f:
+                    for d in f.keys():
+                        del f[d]
 
-    save_meshwork_metadata(filename, mw)
-    save_meshwork_mesh(filename, mw)
-    save_meshwork_skeleton(filename, mw)
-    save_meshwork_annotations(filename, mw)
+    save_meshwork_metadata(filename, mw, version=version)
+    save_meshwork_mesh(filename, mw, version=version)
+    save_meshwork_skeleton(filename, mw, version=version)
+    save_meshwork_annotations(filename, mw, version=version)
 
 
 def _load_meshwork(filename):
     meta = load_meshwork_metadata(filename)
-    mesh, mask = load_meshwork_mesh(filename)
-    skel = load_meshwork_skeleton(filename)
-    annos = load_meshwork_annotations(filename)
+    version = meta.get("version")
+    mesh, mask = load_meshwork_mesh(filename, version=version)
+    skel = load_meshwork_skeleton(filename, version=version)
+    annos = load_meshwork_annotations(filename, version=version)
     return meta, mesh, skel, annos, mask

--- a/meshparty/skeleton.py
+++ b/meshparty/skeleton.py
@@ -44,6 +44,7 @@ class SkeletonMetadata:
 
     # Fields used for skeletonization
     _skeletonize_fields = [
+        "soma_pt",
         "soma_radius",
         "collapse_soma",
         "collapse_function",
@@ -54,7 +55,7 @@ class SkeletonMetadata:
         "smooth_iterations",
         "smooth_neighborhood",
         "smooth_r",
-        "cc_vertex_thres",
+        "cc_vertex_thresh",
         "remove_zero_length_edges",
         "collapse_params",
     ]
@@ -87,9 +88,20 @@ class SkeletonMetadata:
         else:
             params["soma_pt"] = None
 
-        for k in self._skeletonize_fields:
-            params.pop(k)
+        for k in list(params.keys()):
+            if k not in self._skeletonize_fields:
+                params.pop(k)
         return params
+
+    def update_metameta(self, metameta):
+        if self.meta is not None:
+            meta_dict = asdict(self.meta)
+        else:
+            meta_dict = {}
+
+        meta_dict.update(metameta)
+        setattr(self, "meta", _metadata_from_dict(meta_dict, "MetaMetadata"))
+        pass
 
 
 class StaticSkeleton:

--- a/meshparty/skeleton_io.py
+++ b/meshparty/skeleton_io.py
@@ -1,13 +1,13 @@
 import os
-from . import trimesh_io
 import h5py
 import json
+from .utils_io import NumpyEncoder
 import numpy as np
 from meshparty import skeleton
 
 
 def write_skeleton_h5(sk, filename, overwrite=False):
-    '''
+    """
     Write a skeleton and its properties to an hdf5 file.
 
     Parameters
@@ -18,20 +18,28 @@ def write_skeleton_h5(sk, filename, overwrite=False):
         Filename of skeleton file.
     overwrite : bool
          Allows overwriting.(default False).
-    '''
-    write_skeleton_h5_by_part(filename,
-                              vertices=sk.vertices,
-                              edges=sk.edges,
-                              mesh_to_skel_map=sk.mesh_to_skel_map,
-                              vertex_properties=sk.vertex_properties,
-                              root=sk.root,
-                              overwrite=overwrite)
+    """
+    write_skeleton_h5_by_part(
+        filename,
+        vertices=sk.vertices,
+        edges=sk.edges,
+        mesh_to_skel_map=sk.mesh_to_skel_map,
+        vertex_properties=sk.vertex_properties,
+        root=sk.root,
+        overwrite=overwrite,
+    )
 
 
-def write_skeleton_h5_by_part(filename, vertices, edges, mesh_to_skel_map=None,
-                              vertex_properties={}, root=None,
-                              overwrite=False):
-    '''
+def write_skeleton_h5_by_part(
+    filename,
+    vertices,
+    edges,
+    mesh_to_skel_map=None,
+    vertex_properties={},
+    root=None,
+    overwrite=False,
+):
+    """
     Helper function for writing all parts of a skeleton file to an h5.
 
     Parameters
@@ -56,35 +64,35 @@ def write_skeleton_h5_by_part(filename, vertices, edges, mesh_to_skel_map=None,
     overwrite : bool
         whether to overwrite file
 
-    '''
+    """
 
     if os.path.isfile(filename):
         if overwrite:
             os.remove(filename)
         else:
             return
-    with h5py.File(filename, 'w') as f:
-        f.create_dataset('vertices', data=vertices, compression='gzip')
-        f.create_dataset('edges', data=edges, compression='gzip')
+    with h5py.File(filename, "w") as f:
+        f.create_dataset("vertices", data=vertices, compression="gzip")
+        f.create_dataset("edges", data=edges, compression="gzip")
         if mesh_to_skel_map is not None:
-            f.create_dataset('mesh_to_skel_map',
-                             data=mesh_to_skel_map, compression='gzip')
+            f.create_dataset(
+                "mesh_to_skel_map", data=mesh_to_skel_map, compression="gzip"
+            )
         if len(vertex_properties) > 0:
-            _write_dict_to_group(f, 'vertex_properties', vertex_properties)
+            _write_dict_to_group(f, "vertex_properties", vertex_properties)
         if root is not None:
-            f.create_dataset('root', data=root)
+            f.create_dataset("root", data=root)
 
 
 def _write_dict_to_group(f, group_name, data_dict):
     d_grp = f.create_group(group_name)
     for d_name, d_data in data_dict.items():
         is_np = type(d_data) is np.ndarray
-        d_grp.create_dataset(
-            d_name, data=json.dumps(d_data, cls=_NumpyEncoder))
+        d_grp.create_dataset(d_name, data=json.dumps(d_data, cls=NumpyEncoder))
 
 
 def read_skeleton_h5_by_part(filename):
-    '''
+    """
     Helper function for extracting all parts of a skeleton file from an h5.
 
     Parameters
@@ -114,35 +122,35 @@ def read_skeleton_h5_by_part(filename):
     bool
         overwrite, whether to overwrite file
 
-    '''
+    """
     assert os.path.isfile(filename)
 
-    with h5py.File(filename, 'r') as f:
-        vertices = f['vertices'][()]
-        edges = f['edges'][()]
+    with h5py.File(filename, "r") as f:
+        vertices = f["vertices"][()]
+        edges = f["edges"][()]
 
-        if 'mesh_to_skel_map' in f.keys():
-            mesh_to_skel_map = f['mesh_to_skel_map'][()]
+        if "mesh_to_skel_map" in f.keys():
+            mesh_to_skel_map = f["mesh_to_skel_map"][()]
         else:
             mesh_to_skel_map = None
 
         vertex_properties = {}
-        if 'vertex_properties' in f.keys():
-            for vp_key in f['vertex_properties'].keys():
-                vertex_properties[vp_key] = json.loads(f['vertex_properties'][vp_key][()],
-                                                       object_hook=_convert_keys_to_int)
+        if "vertex_properties" in f.keys():
+            for vp_key in f["vertex_properties"].keys():
+                vertex_properties[vp_key] = json.loads(
+                    f["vertex_properties"][vp_key][()], object_hook=_convert_keys_to_int
+                )
 
-        if 'root' in f.keys():
-            root = f['root'][()]
+        if "root" in f.keys():
+            root = f["root"][()]
         else:
             root = None
 
     return vertices, edges, mesh_to_skel_map, vertex_properties, root
 
 
-def read_skeleton_h5(filename,
-                     remove_zero_length_edges=False):
-    '''
+def read_skeleton_h5(filename, remove_zero_length_edges=False):
+    """
     Reads a skeleton and its properties from an hdf5 file.
 
     Parameters
@@ -157,19 +165,28 @@ def read_skeleton_h5(filename,
     :obj:`meshparty.skeleton.Skeleton`
         skeleton object loaded from the h5 file
 
-    '''
-    vertices, edges, mesh_to_skel_map, vertex_properties, root = read_skeleton_h5_by_part(
-        filename)
-    return skeleton.Skeleton(vertices=vertices,
-                             edges=edges,
-                             mesh_to_skel_map=mesh_to_skel_map,
-                             vertex_properties=vertex_properties,
-                             root=root,
-                             remove_zero_length_edges=remove_zero_length_edges)
+    """
+    (
+        vertices,
+        edges,
+        mesh_to_skel_map,
+        vertex_properties,
+        root,
+    ) = read_skeleton_h5_by_part(filename)
+    return skeleton.Skeleton(
+        vertices=vertices,
+        edges=edges,
+        mesh_to_skel_map=mesh_to_skel_map,
+        vertex_properties=vertex_properties,
+        root=root,
+        remove_zero_length_edges=remove_zero_length_edges,
+    )
 
 
-def export_to_swc(skel, filename, node_labels=None, radius=None, header=None, xyz_scaling=1000):
-    '''
+def export_to_swc(
+    skel, filename, node_labels=None, radius=None, header=None, xyz_scaling=1000
+):
+    """
     Export a skeleton file to an swc file
     (see http://research.mssm.edu/cnic/swc.html for swc definition)
 
@@ -185,18 +202,18 @@ def export_to_swc(skel, filename, node_labels=None, radius=None, header=None, xy
         None (default) or an iterable of floats. This should be co-indexed with vertices.
         Radius values are assumed to be in the same units as the node vertices.
     header : str or list, default None.
-        An optional header string for the file. Each element of the list 
+        An optional header string for the file. Each element of the list
     xyz_scaling: Number, default 1000. Down-scales spatial units from the skeleton's units to
                         whatever is desired by the swc. E.g. nm to microns has scaling=1000.
-    '''
+    """
 
     if header is None:
-        header_string = ''
+        header_string = ""
     else:
         if isinstance(header, str):
             header = [header]
-        header[0] = ' '.join(['#', header[0]])
-        header_string = '\n# '.join(header)
+        header[0] = " ".join(["#", header[0]])
+        header_string = "\n# ".join(header)
 
     if radius is None:
         radius = np.full(len(skel.vertices), 1000)
@@ -208,15 +225,21 @@ def export_to_swc(skel, filename, node_labels=None, radius=None, header=None, xy
 
     swc_dat = _build_swc_array(skel, node_labels, radius, xyz_scaling)
 
-    with open(filename, 'w') as f:
-        np.savetxt(f, swc_dat, delimiter=' ', header=header_string, comments='#',
-                   fmt=['%i', '%i', '%.3f', '%.3f', '%.3f', '%.3f', '%i'])
+    with open(filename, "w") as f:
+        np.savetxt(
+            f,
+            swc_dat,
+            delimiter=" ",
+            header=header_string,
+            comments="#",
+            fmt=["%i", "%i", "%.3f", "%.3f", "%.3f", "%.3f", "%i"],
+        )
 
 
 def _build_swc_array(skel, node_labels, radius, xyz_scaling):
-    '''
+    """
     Helper function for producing the numpy table for an swc.
-    '''
+    """
     order_old = np.concatenate([p[::-1] for p in skel.cover_paths])
     new_ids = np.arange(skel.n_vertices)
     order_map = dict(zip(order_old, new_ids))
@@ -224,29 +247,18 @@ def _build_swc_array(skel, node_labels, radius, xyz_scaling):
     node_labels = np.array(node_labels)[order_old]
     xyz = skel.vertices[order_old]
     radius = radius[order_old]
-    par_ids = np.array([order_map.get(nid, -1)
-                        for nid in skel.parent_nodes(order_old)])
+    par_ids = np.array([order_map.get(nid, -1) for nid in skel.parent_nodes(order_old)])
 
-    swc_dat = np.hstack((new_ids[:, np.newaxis],
-                         node_labels[:, np.newaxis],
-                         xyz / xyz_scaling,
-                         radius[:, np.newaxis] / xyz_scaling,
-                         par_ids[:, np.newaxis]))
+    swc_dat = np.hstack(
+        (
+            new_ids[:, np.newaxis],
+            node_labels[:, np.newaxis],
+            xyz / xyz_scaling,
+            radius[:, np.newaxis] / xyz_scaling,
+            par_ids[:, np.newaxis],
+        )
+    )
     return swc_dat
-
-
-class _NumpyEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, (np.int_, np.intc, np.intp, np.int8,
-                            np.int16, np.int32, np.int64, np.uint8,
-                            np.uint16, np.uint32, np.uint64)):
-            return int(obj)
-        elif isinstance(obj, (np.float_, np.float16, np.float32,
-                              np.float64)):
-            return float(obj)
-        elif isinstance(obj, (np.ndarray,)):
-            return obj.tolist()
-        return json.JSONEncoder.default(self, obj)
 
 
 def _convert_keys_to_int(x):

--- a/meshparty/skeletonize.py
+++ b/meshparty/skeletonize.py
@@ -1,28 +1,41 @@
 from scipy import sparse, spatial, optimize, signal
 import numpy as np
 import time
-from meshparty import utils, mesh_filters
-import pandas as pd
+from meshparty import utils
+
 try:
     from pykdtree.kdtree import KDTree
 except:
     KDTree = spatial.cKDTree
-from tqdm import trange, tqdm
-from meshparty.trimesh_io import Mesh
+from tqdm import tqdm
 from meshparty.skeleton import Skeleton
-from collections import defaultdict
 from .ray_tracing import ray_trace_distance, shape_diameter_function
 import fastremap
 import logging
 
 
-def skeletonize_mesh(mesh, soma_pt=None, soma_radius=7500, collapse_soma=True, collapse_function='sphere',
-                     invalidation_d=12000, smooth_vertices=False, compute_radius=True,
-                     shape_function='single', compute_original_index=True, verbose=True,
-                     smooth_iterations=12, smooth_neighborhood=2, smooth_r=0.1,
-                     cc_vertex_thresh=100, root_index=None,
-                     remove_zero_length_edges=True, collapse_params={}):
-    '''
+def skeletonize_mesh(
+    mesh,
+    soma_pt=None,
+    soma_radius=7500,
+    collapse_soma=True,
+    collapse_function="sphere",
+    invalidation_d=12000,
+    smooth_vertices=False,
+    compute_radius=True,
+    shape_function="single",
+    compute_original_index=True,
+    verbose=True,
+    smooth_iterations=12,
+    smooth_neighborhood=2,
+    smooth_r=0.1,
+    cc_vertex_thresh=100,
+    root_index=None,
+    remove_zero_length_edges=True,
+    collapse_params={},
+    meta={},
+):
+    """
     Build skeleton object from mesh skeletonization
 
     Parameters
@@ -32,9 +45,9 @@ def skeletonize_mesh(mesh, soma_pt=None, soma_radius=7500, collapse_soma=True, c
     soma_pt: np.array
         a length 3 array specifying to soma location to make the root
         default=None, in which case a heuristic root will be chosen
-        in units of mesh vertices. 
+        in units of mesh vertices.
     soma_radius: float
-        distance in mesh vertex units over which to consider mesh 
+        distance in mesh vertex units over which to consider mesh
         vertices close to soma_pt to belong to soma
         these vertices will automatically be invalidated and no
         skeleton branches will attempt to reach them.
@@ -77,21 +90,35 @@ def skeletonize_mesh(mesh, soma_pt=None, soma_radius=7500, collapse_soma=True, c
         Smallest number of vertices in a connected component to skeletonize.
     verbose: bool
         whether to print verbose logging
+    meta: dict
+        Skeletonization metadata to add to the skeleton. See skeleton.SkeletonMetadata for keys.
 
     Returns
     -------
     :obj:`meshparty.skeleton.Skeleton`
            a Skeleton object for this mesh
-    '''
-    skel_verts, skel_edges, orig_skel_index, skel_map = calculate_skeleton_paths_on_mesh(mesh,
-                                                                                         invalidation_d=invalidation_d,
-                                                                                         cc_vertex_thresh=cc_vertex_thresh,
-                                                                                         root_index=root_index,
-                                                                                         return_map=True)
+    """
+    (
+        skel_verts,
+        skel_edges,
+        orig_skel_index,
+        skel_map,
+    ) = calculate_skeleton_paths_on_mesh(
+        mesh,
+        invalidation_d=invalidation_d,
+        cc_vertex_thresh=cc_vertex_thresh,
+        root_index=root_index,
+        return_map=True,
+    )
 
     if smooth_vertices is True:
         smooth_verts = smooth_graph(
-            skel_verts, skel_edges, neighborhood=smooth_neighborhood, iterations=smooth_iterations, r=smooth_r)
+            skel_verts,
+            skel_edges,
+            neighborhood=smooth_neighborhood,
+            iterations=smooth_iterations,
+            r=smooth_r,
+        )
         skel_verts = smooth_verts
 
     if root_index is not None and soma_pt is None:
@@ -100,51 +127,60 @@ def skeletonize_mesh(mesh, soma_pt=None, soma_radius=7500, collapse_soma=True, c
     rs = None
 
     if collapse_soma is True and soma_pt is not None:
-        # skel_map[np.isnan(skel_map)] = len(skel_verts)
-        temp_sk = Skeleton(skel_verts, skel_edges,
-                           mesh_index=mesh.map_indices_to_unmasked(
-                               orig_skel_index),
-                           mesh_to_skel_map=skel_map)
+        temp_sk = Skeleton(
+            skel_verts,
+            skel_edges,
+            mesh_index=mesh.map_indices_to_unmasked(orig_skel_index),
+            mesh_to_skel_map=skel_map,
+        )
         soma_pt = np.array(soma_pt).reshape(1, 3)
         _, close_ind = temp_sk.kdtree.query(soma_pt)
         temp_sk.reroot(close_ind[0])
 
-        if collapse_function == 'sphere':
+        if collapse_function == "sphere":
             soma_verts, soma_r = soma_via_sphere(
-                soma_pt, temp_sk.vertices, temp_sk.edges, soma_radius)
-        elif collapse_function == 'branch':
+                soma_pt, temp_sk.vertices, temp_sk.edges, soma_radius
+            )
+        elif collapse_function == "branch":
 
-            if shape_function == 'single':
+            if shape_function == "single":
                 rs = ray_trace_distance(
-                    mesh.filter_unmasked_indices_padded(temp_sk.mesh_index), mesh)
-            elif shape_function == 'cone':
-                rs = shape_diameter_function(mesh.filter_unmasked_indices_padded(
-                    temp_sk.mesh_index), mesh, num_points=30, cone_angle=np.pi/3)
+                    mesh.filter_unmasked_indices_padded(temp_sk.mesh_index), mesh
+                )
+            elif shape_function == "cone":
+                rs = shape_diameter_function(
+                    mesh.filter_unmasked_indices_padded(temp_sk.mesh_index),
+                    mesh,
+                    num_points=30,
+                    cone_angle=np.pi / 3,
+                )
 
-            soma_verts, soma_r = soma_via_branch_starts(temp_sk,
-                                                        mesh,
-                                                        soma_pt,
-                                                        rs,
-                                                        search_radius=collapse_params.get(
-                                                            'search_radius', 25000),
-                                                        fallback_radius=collapse_params.get(
-                                                            'fallback_radius', soma_radius),
-                                                        cutoff_threshold=collapse_params.get(
-                                                            'cutoff_threshold', 0.4),
-                                                        min_cutoff=collapse_params.get(
-                                                            'min_cutoff', 0.1),
-                                                        dynamic_range=collapse_params.get(
-                                                            'dynamic_range', 1),
-                                                        dynamic_threshold=collapse_params.get(
-                                                            'dynamic_threshold', False)
-                                                        )
+            soma_verts, soma_r = soma_via_branch_starts(
+                temp_sk,
+                mesh,
+                soma_pt,
+                rs,
+                search_radius=collapse_params.get("search_radius", 25000),
+                fallback_radius=collapse_params.get("fallback_radius", soma_radius),
+                cutoff_threshold=collapse_params.get("cutoff_threshold", 0.4),
+                min_cutoff=collapse_params.get("min_cutoff", 0.1),
+                dynamic_range=collapse_params.get("dynamic_range", 1),
+                dynamic_threshold=collapse_params.get("dynamic_threshold", False),
+            )
         if root_index is not None:
             collapse_index = np.flatnonzero(orig_skel_index == root_index)[0]
         else:
             collapse_index = None
-        new_v, new_e, new_skel_map, vert_filter, root_ind = collapse_soma_skeleton(soma_verts, soma_pt, temp_sk.vertices, temp_sk.edges,
-                                                                                   mesh_to_skeleton_map=temp_sk.mesh_to_skel_map,
-                                                                                   collapse_index=collapse_index, return_filter=True, return_soma_ind=True)
+        new_v, new_e, new_skel_map, vert_filter, root_ind = collapse_soma_skeleton(
+            soma_verts,
+            soma_pt,
+            temp_sk.vertices,
+            temp_sk.edges,
+            mesh_to_skeleton_map=temp_sk.mesh_to_skel_map,
+            collapse_index=collapse_index,
+            return_filter=True,
+            return_soma_ind=True,
+        )
     else:
         new_v, new_e, new_skel_map = skel_verts, skel_edges, skel_map
         vert_filter = np.arange(len(orig_skel_index))
@@ -155,8 +191,9 @@ def skeletonize_mesh(mesh, soma_pt=None, soma_radius=7500, collapse_soma=True, c
             root_ind = utils.find_far_points_graph(sk_graph)[0]
         else:
             # Still try to root close to the soma
-            _, qry_inds = spatial.cKDTree(
-                new_v, balanced_tree=False).query(soma_pt[np.newaxis, :])
+            _, qry_inds = spatial.cKDTree(new_v, balanced_tree=False).query(
+                soma_pt[np.newaxis, :]
+            )
             root_ind = qry_inds[0]
 
     skel_map_full_mesh = np.full(mesh.node_mask.shape, -1, dtype=np.int64)
@@ -173,15 +210,14 @@ def skeletonize_mesh(mesh, soma_pt=None, soma_radius=7500, collapse_soma=True, c
                 mesh_index = np.append(mesh_index, -1)
         else:
             mesh_index = orig_skel_index[vert_filter]
-        props['mesh_index'] = mesh_index
+        props["mesh_index"] = mesh_index
 
     if compute_radius is True:
         if rs is None:
-            if shape_function == 'single':
+            if shape_function == "single":
                 rs = ray_trace_distance(orig_skel_index[vert_filter], mesh)
-            elif shape_function == 'cone':
-                rs = shape_diameter_function(
-                    orig_skel_index[vert_filter], mesh)
+            elif shape_function == "cone":
+                rs = shape_diameter_function(orig_skel_index[vert_filter], mesh)
         else:
             rs = rs[vert_filter]
         if collapse_soma is True and soma_pt is not None:
@@ -189,11 +225,39 @@ def skeletonize_mesh(mesh, soma_pt=None, soma_radius=7500, collapse_soma=True, c
                 rs = np.append(rs, soma_r)
             else:
                 rs[root_ind] = soma_r
-        props['rs'] = rs
+        props["rs"] = rs
 
-    sk = Skeleton(new_v, new_e, mesh_to_skel_map=skel_map_full_mesh,
-                  mesh_index=props.get('mesh_index', None), radius=props.get('rs', None), root=root_ind,
-                  remove_zero_length_edges=remove_zero_length_edges)
+    sk_params = {
+        "soma_pt_x": soma_pt[0] if soma_pt is not None else None,
+        "soma_pt_y": soma_pt[1] if soma_pt is not None else None,
+        "soma_pt_z": soma_pt[2] if soma_pt is not None else None,
+        "soma_radius": soma_radius,
+        "collapse_soma": collapse_soma,
+        "collapse_function": collapse_function,
+        "invalidation_d": invalidation_d,
+        "smooth_vertices": smooth_vertices,
+        "compute_radius": compute_radius,
+        "shape_function": shape_function,
+        "smooth_iterations": smooth_iterations,
+        "smooth_neighborhood": smooth_neighborhood,
+        "smooth_r": smooth_r,
+        "cc_vertex_thresh": cc_vertex_thresh,
+        "remove_zero_length_edges": remove_zero_length_edges,
+        "collapse_params": collapse_params,
+        "timestamp": time.time(),
+    }
+    sk_params.update(meta)
+
+    sk = Skeleton(
+        new_v,
+        new_e,
+        mesh_to_skel_map=skel_map_full_mesh,
+        mesh_index=props.get("mesh_index", None),
+        radius=props.get("rs", None),
+        root=root_ind,
+        remove_zero_length_edges=remove_zero_length_edges,
+        meta=sk_params,
+    )
 
     if compute_radius is True:
         _remove_nan_radius(sk)
@@ -210,7 +274,7 @@ def _remove_nan_radius(sk, set_unfixed_to_lowest=True):
         for nanloc in nanlocs:
             sparse_row = sk.csgraph_binary_undirected[nanloc].toarray().ravel()
             prod = sparse_row * sk.radius
-            with np.errstate(divide='ignore', invalid='ignore'):
+            with np.errstate(divide="ignore", invalid="ignore"):
                 new_rad = np.nansum(prod) / np.nansum(prod > 0)
             sk._rooted.radius[nanloc] = new_rad
         last_numnans = numnans
@@ -221,17 +285,19 @@ def _remove_nan_radius(sk, set_unfixed_to_lowest=True):
         sk._rooted.radius[nanlocs] = np.nanmin(sk.radius)
 
 
-def calculate_skeleton_paths_on_mesh(mesh,
-                                     soma_pt=None,
-                                     soma_thresh=7500,
-                                     invalidation_d=10000,
-                                     smooth_neighborhood=2,
-                                     smooth_iterations=12,
-                                     cc_vertex_thresh=100,
-                                     large_skel_path_threshold=5000,
-                                     return_map=False,
-                                     root_index=None):
-    """ function to turn a trimesh object of a neuron into a skeleton, without running soma collapse,
+def calculate_skeleton_paths_on_mesh(
+    mesh,
+    soma_pt=None,
+    soma_thresh=7500,
+    invalidation_d=10000,
+    smooth_neighborhood=2,
+    smooth_iterations=12,
+    cc_vertex_thresh=100,
+    large_skel_path_threshold=5000,
+    return_map=False,
+    root_index=None,
+):
+    """function to turn a trimesh object of a neuron into a skeleton, without running soma collapse,
     or recasting result into a Skeleton.  Used by :func:`meshparty.skeletonize.skeletonize_mesh` and
     makes use of :func:`meshparty.skeletonize.skeletonize_components`
 
@@ -244,7 +310,7 @@ def calculate_skeleton_paths_on_mesh(mesh,
         default=None, in which case a heuristic root will be chosen
         in units of mesh vertices
     soma_thresh: float
-        distance in mesh vertex units over which to consider mesh 
+        distance in mesh vertex units over which to consider mesh
         vertices close to soma_pt to belong to soma
         these vertices will automatically be invalidated and no
         skeleton branches will attempt to reach them.
@@ -261,7 +327,7 @@ def calculate_skeleton_paths_on_mesh(mesh,
         (default 5)
     large_skel_path_threshold: int
         the threshold in terms of skeleton vertices that skeletons will be
-        nominated for tip merging.  Smaller skeleton fragments 
+        nominated for tip merging.  Smaller skeleton fragments
         will not be merged at their tips (default 5000)
     cc_vertex_thresh: int
         the threshold in terms of vertex numbers that connected components
@@ -289,13 +355,15 @@ def calculate_skeleton_paths_on_mesh(mesh,
 
     """
 
-    skeletonize_output = skeletonize_components(mesh,
-                                                soma_pt=soma_pt,
-                                                soma_thresh=soma_thresh,
-                                                invalidation_d=invalidation_d,
-                                                cc_vertex_thresh=cc_vertex_thresh,
-                                                return_map=return_map,
-                                                root_index=root_index)
+    skeletonize_output = skeletonize_components(
+        mesh,
+        soma_pt=soma_pt,
+        soma_thresh=soma_thresh,
+        invalidation_d=invalidation_d,
+        cc_vertex_thresh=cc_vertex_thresh,
+        return_map=return_map,
+        root_index=root_index,
+    )
     if return_map is True:
         all_paths, roots, tot_path_lengths, mesh_to_skeleton_map = skeletonize_output
     else:
@@ -309,12 +377,12 @@ def calculate_skeleton_paths_on_mesh(mesh,
     else:
         tot_edges = np.zeros((3, 0))
 
-    skel_verts, skel_edges, skel_verts_orig = reduce_verts(
-        mesh.vertices, tot_edges)
+    skel_verts, skel_edges, skel_verts_orig = reduce_verts(mesh.vertices, tot_edges)
 
     if return_map:
         mesh_to_skeleton_map = utils.nanfilter_shapes(
-            np.unique(tot_edges.ravel()), mesh_to_skeleton_map)
+            np.unique(tot_edges.ravel()), mesh_to_skeleton_map
+        )
         mesh_to_skeleton_map[np.isnan(mesh_to_skeleton_map)] = -1
     else:
         mesh_to_skeleton_map = None
@@ -339,9 +407,9 @@ def reduce_verts(verts, faces):
         (entries are indices into verts)
 
     Returns
-    ------- 
+    -------
     np.array
-        new_verts, a filtered set of vertices 
+        new_verts, a filtered set of vertices
     np.array
         new_face, a reindexed set of faces (or edges)
     np.array
@@ -356,19 +424,21 @@ def reduce_verts(verts, faces):
     return new_verts, new_face, used_verts
 
 
-def skeletonize_components(mesh,
-                           soma_pt=None,
-                           soma_thresh=10000,
-                           invalidation_d=10000,
-                           cc_vertex_thresh=100,
-                           return_map=False,
-                           root_index=None):
-    """ core skeletonization routine, used by :func:`meshparty.skeletonize.calculate_skeleton_paths_on_mesh`
-    to calculate skeleton on all components of mesh, with no post processing """
+def skeletonize_components(
+    mesh,
+    soma_pt=None,
+    soma_thresh=10000,
+    invalidation_d=10000,
+    cc_vertex_thresh=100,
+    return_map=False,
+    root_index=None,
+):
+    """core skeletonization routine, used by :func:`meshparty.skeletonize.calculate_skeleton_paths_on_mesh`
+    to calculate skeleton on all components of mesh, with no post processing"""
     # find all the connected components in the mesh
-    n_components, labels = sparse.csgraph.connected_components(mesh.csgraph,
-                                                               directed=False,
-                                                               return_labels=True)
+    n_components, labels = sparse.csgraph.connected_components(
+        mesh.csgraph, directed=False, return_labels=True
+    )
     comp_labels, comp_counts = np.unique(labels, return_counts=True)
 
     if return_map:
@@ -380,8 +450,7 @@ def skeletonize_components(mesh,
     tot_path_lengths = []
 
     if root_index is not None:
-        soma_d = np.linalg.norm(
-            mesh.vertices - mesh.vertices[root_index], axis=1)
+        soma_d = np.linalg.norm(mesh.vertices - mesh.vertices[root_index], axis=1)
         is_soma_pt = np.arange(len(mesh.vertices)) == root_index
     elif soma_pt is not None:
         soma_d = mesh.vertices - soma_pt.reshape(1, 3)
@@ -400,24 +469,26 @@ def skeletonize_components(mesh,
             # find the root using a soma position if you have it
             # it will fall back to a heuristic if the soma
             # is too far away for this component
-            root, root_ds, pred, valid = setup_root(mesh,
-                                                    is_soma_pt,
-                                                    soma_d,
-                                                    labels == k)
+            root, root_ds, pred, valid = setup_root(
+                mesh, is_soma_pt, soma_d, labels == k
+            )
             # run teasar on this component
-            teasar_output = mesh_teasar(mesh,
-                                        root=root,
-                                        root_ds=root_ds,
-                                        root_pred=pred,
-                                        valid=valid,
-                                        invalidation_d=invalidation_d,
-                                        return_map=return_map)
+            teasar_output = mesh_teasar(
+                mesh,
+                root=root,
+                root_ds=root_ds,
+                root_pred=pred,
+                valid=valid,
+                invalidation_d=invalidation_d,
+                return_map=return_map,
+            )
             if return_map is False:
                 paths, path_lengths = teasar_output
             else:
                 paths, path_lengths, mesh_to_skeleton_map_single = teasar_output
-                mesh_to_skeleton_map[~np.isnan(
-                    mesh_to_skeleton_map_single)] = mesh_to_skeleton_map_single[~np.isnan(mesh_to_skeleton_map_single)]
+                mesh_to_skeleton_map[
+                    ~np.isnan(mesh_to_skeleton_map_single)
+                ] = mesh_to_skeleton_map_single[~np.isnan(mesh_to_skeleton_map_single)]
 
             if len(path_lengths) > 0:
                 # collect the results in lists
@@ -437,61 +508,71 @@ def setup_root(mesh, is_soma_pt=None, soma_d=None, is_valid=None):
         valid = np.copy(is_valid)
     else:
         valid = np.ones(len(mesh.vertices), np.bool)
-    assert(len(valid) == mesh.vertices.shape[0])
+    assert len(valid) == mesh.vertices.shape[0]
 
     root = None
     # soma mode
     if is_soma_pt is not None:
         # pick the first soma as root
-        assert(len(soma_d) == mesh.vertices.shape[0])
-        assert(len(is_soma_pt) == mesh.vertices.shape[0])
+        assert len(soma_d) == mesh.vertices.shape[0]
+        assert len(is_soma_pt) == mesh.vertices.shape[0]
         is_valid_root = is_soma_pt & valid
         valid_root_inds = np.where(is_valid_root)[0]
         if len(valid_root_inds) > 0:
             min_valid_root = np.nanargmin(soma_d[valid_root_inds])
             root = valid_root_inds[min_valid_root]
-            root_ds, pred = sparse.csgraph.dijkstra(mesh.csgraph,
-                                                    directed=False,
-                                                    indices=root,
-                                                    return_predecessors=True)
+            root_ds, pred = sparse.csgraph.dijkstra(
+                mesh.csgraph, directed=False, indices=root, return_predecessors=True
+            )
         else:
             start_ind = np.where(valid)[0][0]
-            root, target, pred, dm, root_ds = utils.find_far_points(mesh,
-                                                                    start_ind=start_ind)
+            root, target, pred, dm, root_ds = utils.find_far_points(
+                mesh, start_ind=start_ind
+            )
         valid[is_soma_pt] = False
 
     if root is None:
         # there is no soma close, so use far point heuristic
         start_ind = np.where(valid)[0][0]
         root, target, pred, dm, root_ds = utils.find_far_points(
-            mesh, start_ind=start_ind)
+            mesh, start_ind=start_ind
+        )
     valid[root] = False
-    assert(np.all(~np.isinf(root_ds[valid])))
+    assert np.all(~np.isinf(root_ds[valid]))
     return root, root_ds, pred, valid
 
 
-def mesh_teasar(mesh, root=None, valid=None, root_ds=None, root_pred=None, soma_pt=None,
-                soma_thresh=7500, invalidation_d=10000, return_timing=False, return_map=False,
-                exclude_edges_sigma=None):
+def mesh_teasar(
+    mesh,
+    root=None,
+    valid=None,
+    root_ds=None,
+    root_pred=None,
+    soma_pt=None,
+    soma_thresh=7500,
+    invalidation_d=10000,
+    return_timing=False,
+    return_map=False,
+    exclude_edges_sigma=None,
+):
     """core skeletonization function used to skeletonize a single component of a mesh"""
     # if no root passed, then calculation one
     if root is None:
-        root, root_ds, root_pred, valid = setup_root(mesh,
-                                                     soma_pt=soma_pt,
-                                                     soma_thresh=soma_thresh)
+        root, root_ds, root_pred, valid = setup_root(
+            mesh, soma_pt=soma_pt, soma_thresh=soma_thresh
+        )
     # if root_ds have not be precalculated do so
     if root_ds is None:
-        root_ds, root_pred = sparse.csgraph.dijkstra(mesh.csgraph,
-                                                     False,
-                                                     root,
-                                                     return_predecessors=True)
+        root_ds, root_pred = sparse.csgraph.dijkstra(
+            mesh.csgraph, False, root, return_predecessors=True
+        )
     # if certain vertices haven't been pre-invalidated start with just
     # the root vertex invalidated
     if valid is None:
         valid = np.ones(len(mesh.vertices), np.bool)
         valid[root] = False
     else:
-        if (len(valid) != len(mesh.vertices)):
+        if len(valid) != len(mesh.vertices):
             raise Exception("valid must be length of vertices")
 
     if return_map == True:
@@ -521,15 +602,15 @@ def mesh_teasar(mesh, root=None, valid=None, root_ds=None, root_pred=None, soma_
 
     with tqdm(total=total_to_visit) as pbar:
         # keep looping till all vertices have been invalidated
-        while(np.sum(valid) > 0):
+        while np.sum(valid) > 0:
             k += 1
             t = time.time()
             # find the next target, farthest vertex from root
             # that has not been invalidated
-            target = np.nanargmax(root_ds*valid)
-            if (np.isinf(root_ds[target])):
-                raise Exception('target cannot be reached')
-            time_arrays[0].append(time.time()-t)
+            target = np.nanargmax(root_ds * valid)
+            if np.isinf(root_ds[target]):
+                raise Exception("target cannot be reached")
+            time_arrays[0].append(time.time() - t)
 
             t = time.time()
             # figure out the longest this branch could be
@@ -542,7 +623,7 @@ def mesh_teasar(mesh, root=None, valid=None, root_ds=None, root_pred=None, soma_
             max_branch = target
             while max_branch not in visited_nodes:
                 max_branch = root_pred[max_branch]
-            max_path_length = root_ds[target]-root_ds[max_branch]
+            max_path_length = root_ds[target] - root_ds[max_branch]
 
             # calculate the shortest path to that vertex
             # from all other vertices
@@ -552,7 +633,8 @@ def mesh_teasar(mesh, root=None, valid=None, root_ds=None, root_pred=None, soma_
                 False,
                 target,
                 limit=max_path_length,
-                return_predecessors=True)
+                return_predecessors=True,
+            )
 
             # pick out the vertex that has already been visited
             # which has the shortest path to target
@@ -561,26 +643,31 @@ def mesh_teasar(mesh, root=None, valid=None, root_ds=None, root_pred=None, soma_
             branch = visited_nodes[min_node]
             # this is in the index of the point on the skeleton
             # we want this branch to connect to
-            time_arrays[1].append(time.time()-t)
+            time_arrays[1].append(time.time() - t)
 
             t = time.time()
             # get the path from the target to branch point
             path = utils.get_path(target, branch, pred_t)
             visited_nodes += path[0:-1]
             # record its length
-            assert(~np.isinf(ds[branch]))
+            assert ~np.isinf(ds[branch])
             path_lengths.append(ds[branch])
             # record the path
             paths.append(path)
-            time_arrays[2].append(time.time()-t)
+            time_arrays[2].append(time.time() - t)
 
             t = time.time()
             # get the distance to all points along the new path
             # within the invalidation distance
             dm, _, sources = sparse.csgraph.dijkstra(
-                mesh.csgraph, False, path, limit=invalidation_d,
-                min_only=True, return_predecessors=True)
-            time_arrays[3].append(time.time()-t)
+                mesh.csgraph,
+                False,
+                path,
+                limit=invalidation_d,
+                min_only=True,
+                return_predecessors=True,
+            )
+            time_arrays[3].append(time.time() - t)
 
             t = time.time()
             # all such non infinite distances are within the invalidation
@@ -588,19 +675,25 @@ def mesh_teasar(mesh, root=None, valid=None, root_ds=None, root_pred=None, soma_
             nodes_to_update = ~np.isinf(dm)
             marked = np.sum(valid & ~np.isinf(dm))
             if return_map == True:
-                new_sources_closer = dm[nodes_to_update] < mesh_to_skeleton_dist[nodes_to_update]
-                mesh_to_skeleton_map[nodes_to_update] = np.where(new_sources_closer,
-                                                                 sources[nodes_to_update],
-                                                                 mesh_to_skeleton_map[nodes_to_update])
-                mesh_to_skeleton_dist[nodes_to_update] = np.where(new_sources_closer,
-                                                                  dm[nodes_to_update],
-                                                                  mesh_to_skeleton_dist[nodes_to_update])
+                new_sources_closer = (
+                    dm[nodes_to_update] < mesh_to_skeleton_dist[nodes_to_update]
+                )
+                mesh_to_skeleton_map[nodes_to_update] = np.where(
+                    new_sources_closer,
+                    sources[nodes_to_update],
+                    mesh_to_skeleton_map[nodes_to_update],
+                )
+                mesh_to_skeleton_dist[nodes_to_update] = np.where(
+                    new_sources_closer,
+                    dm[nodes_to_update],
+                    mesh_to_skeleton_dist[nodes_to_update],
+                )
 
             valid[~np.isinf(dm)] = False
 
             # print out how many vertices are still valid
             pbar.update(marked)
-            time_arrays[4].append(time.time()-t)
+            time_arrays[4].append(time.time() - t)
     # record the total time
     dt = time.time() - start
 
@@ -613,50 +706,49 @@ def mesh_teasar(mesh, root=None, valid=None, root_ds=None, root_pred=None, soma_
     return out_tuple
 
 
-def smooth_graph(values, edges, mask=None, neighborhood=2, iterations=100, r=.1):
-    """ smooths a spatial graph via iterative local averaging
-        calculates the average value of neighboring values
-        and relaxes the values toward that average
+def smooth_graph(values, edges, mask=None, neighborhood=2, iterations=100, r=0.1):
+    """smooths a spatial graph via iterative local averaging
+    calculates the average value of neighboring values
+    and relaxes the values toward that average
 
-        Parameters
-        ----------
-        values : numpy.array
-            a NxK numpy array of values, for example xyz positions
-        edges : numpy.array
-            a Mx2 numpy array of indices into values that are edges
-        mask : numpy.array
-            NOT yet implemented
-            optional N boolean vector of values to mask
-            the vert locations.  the result will return a result at every vert
-            but the values that are false in this mask will be ignored and not
-            factored into the smoothing.
-        neighborhood : int
-            an integer of how far in the graph to relax over
-            as being local to any vertex (default = 2)
-        iterations : int
-            number of relaxation iterations (default = 100)
-        r : float
-            relaxation factor at each iteration
-            new_vertex = (1-r)*old_vertex*mask + (r+(1-r)*(1-mask))*(local_avg)
-            default = .1
+    Parameters
+    ----------
+    values : numpy.array
+        a NxK numpy array of values, for example xyz positions
+    edges : numpy.array
+        a Mx2 numpy array of indices into values that are edges
+    mask : numpy.array
+        NOT yet implemented
+        optional N boolean vector of values to mask
+        the vert locations.  the result will return a result at every vert
+        but the values that are false in this mask will be ignored and not
+        factored into the smoothing.
+    neighborhood : int
+        an integer of how far in the graph to relax over
+        as being local to any vertex (default = 2)
+    iterations : int
+        number of relaxation iterations (default = 100)
+    r : float
+        relaxation factor at each iteration
+        new_vertex = (1-r)*old_vertex*mask + (r+(1-r)*(1-mask))*(local_avg)
+        default = .1
 
-        Returns
-        -------
-        np.array
-            new_verts, a Nx3 list of new smoothed vertex positions
+    Returns
+    -------
+    np.array
+        new_verts, a Nx3 list of new smoothed vertex positions
 
     """
     N = len(values)
     E = len(edges)
 
     # setup a sparse matrix with the edges
-    sm = sparse.csc_matrix(
-        (np.ones(E), (edges[:, 0], edges[:, 1])), shape=(N, N))
+    sm = sparse.csc_matrix((np.ones(E), (edges[:, 0], edges[:, 1])), shape=(N, N))
 
     # an identity matrix
-    eye = sparse.csc_matrix((np.ones(N, dtype=np.float32),
-                             (np.arange(0, N), np.arange(0, N))),
-                            shape=(N, N))
+    eye = sparse.csc_matrix(
+        (np.ones(N, dtype=np.float32), (np.arange(0, N), np.arange(0, N))), shape=(N, N)
+    )
     # for undirected graphs we want it symettric
     sm = sm + sm.T
 
@@ -674,7 +766,7 @@ def smooth_graph(values, edges, mask=None, neighborhood=2, iterations=100, r=.1)
     neighbors = np.sum(C, axis=1)
 
     # normalize the weights of neighbors according to number of neighbors
-    neighbors = 1/neighbors
+    neighbors = 1 / neighbors
     C = C.multiply(neighbors)
     # convert back to csc
     C = C.tocsc()
@@ -683,45 +775,43 @@ def smooth_graph(values, edges, mask=None, neighborhood=2, iterations=100, r=.1)
     C *= r
 
     # construct relaxation matrix, adding on identity with complementary weight
-    A = C + (1-r)*eye
+    A = C + (1 - r) * eye
 
     # make a copy of original vertices to no destroy inpuyt
     new_values = np.copy(values)
 
     # iteratively relax the vertices
     for i in range(iterations):
-        new_values = A*new_values
+        new_values = A * new_values
     return new_values
 
 
 def soma_via_sphere(soma_pt, verts, edges, soma_d_thresh):
-    """ Get indices within soma_d_thresh of a soma_pt. Exclude vertices that left and come back.
-    """
-    closest_soma_ind = np.argmin(np.linalg.norm(verts-soma_pt, axis=1))
-    close_inds = np.linalg.norm(verts-soma_pt, axis=1) < soma_d_thresh
+    """Get indices within soma_d_thresh of a soma_pt. Exclude vertices that left and come back."""
+    closest_soma_ind = np.argmin(np.linalg.norm(verts - soma_pt, axis=1))
+    close_inds = np.linalg.norm(verts - soma_pt, axis=1) < soma_d_thresh
     orig_graph = utils.create_csgraph(verts, edges, euclidean_weight=False)
     speye = sparse.diags(close_inds.astype(int))
     _, compids = sparse.csgraph.connected_components(orig_graph * speye)
     return np.flatnonzero(compids[closest_soma_ind] == compids), soma_d_thresh
 
 
-def soma_via_branch_starts(sk,
-                           mesh,
-                           soma_pt,
-                           rs,
-                           search_radius=20000,
-                           fallback_radius=15000,
-                           cutoff_threshold=0.2,
-                           min_cutoff=0.1,
-                           dynamic_range=1,
-                           dynamic_threshold=False,
-                           ):
-    """Runs down paths into the soma region and finds onset of each branch.
-    """
+def soma_via_branch_starts(
+    sk,
+    mesh,
+    soma_pt,
+    rs,
+    search_radius=20000,
+    fallback_radius=15000,
+    cutoff_threshold=0.2,
+    min_cutoff=0.1,
+    dynamic_range=1,
+    dynamic_threshold=False,
+):
+    """Runs down paths into the soma region and finds onset of each branch."""
 
     is_close = np.linalg.norm(sk.vertices - soma_pt, axis=1) < search_radius
-    is_close_fallback = np.linalg.norm(
-        sk.vertices-soma_pt, axis=1) < fallback_radius
+    is_close_fallback = np.linalg.norm(sk.vertices - soma_pt, axis=1) < fallback_radius
 
     # Find segments that emerge from the soma region
     close_segs = []
@@ -742,11 +832,11 @@ def soma_via_branch_starts(sk,
     rs = rs[close_inds]
     rs_long = np.full(sk.n_vertices, np.nan)
     rs_long[close_inds] = rs
-    sk.reroot(close_inds[np.argmin(np.abs(rs-np.percentile(rs, 98)))])
+    sk.reroot(close_inds[np.argmin(np.abs(rs - np.percentile(rs, 98)))])
 
     # Fit a logistic curve
     def log_func(x, h, k, xh, a):
-        return h / (1 + np.exp(-k * (xh-x))) + a
+        return h / (1 + np.exp(-k * (xh - x))) + a
 
     all_params = []
     soma_votes = []
@@ -763,26 +853,37 @@ def soma_via_branch_starts(sk,
 
         try:
             # sig = ydata_filt * log_func( (np.max(xdata)-xdata), 1, 2, 3, 1)
-            sig = np.where(ydata_filt < 2, 2, ydata_filt) * \
-                log_func((np.max(xdata)-xdata), 2, 1, 5, 1)
-            params, _ = optimize.curve_fit(log_func,
-                                           xdata,
-                                           ydata_filt,
-                                           sigma=sig,
-                                           bounds=([0, 0.5, 0, 0],
-                                                   [np.inf, 5, np.inf, np.inf]),
-                                           p0=(10, 1, 10, 1),
-                                           method='trf')
+            sig = np.where(ydata_filt < 2, 2, ydata_filt) * log_func(
+                (np.max(xdata) - xdata), 2, 1, 5, 1
+            )
+            params, _ = optimize.curve_fit(
+                log_func,
+                xdata,
+                ydata_filt,
+                sigma=sig,
+                bounds=([0, 0.5, 0, 0], [np.inf, 5, np.inf, np.inf]),
+                p0=(10, 1, 10, 1),
+                method="trf",
+            )
             all_params.append(params)
             if dynamic_threshold:
                 cutoff_threshold_eff = np.min(
-                    [cutoff_threshold, min_cutoff + (cutoff_threshold-min_cutoff) * np.max([0, (params[1]-0.5)/dynamic_range])])
+                    [
+                        cutoff_threshold,
+                        min_cutoff
+                        + (cutoff_threshold - min_cutoff)
+                        * np.max([0, (params[1] - 0.5) / dynamic_range]),
+                    ]
+                )
             else:
                 cutoff_threshold_eff = cutoff_threshold
 
-            def f(x): return log_func(x, *params) - \
-                (params[3] + cutoff_threshold_eff * (params[0] - params[3]))
-            opt_sol = optimize.root_scalar(f,  bracket=[0, xdata.max()])
+            def f(x):
+                return log_func(x, *params) - (
+                    params[3] + cutoff_threshold_eff * (params[0] - params[3])
+                )
+
+            opt_sol = optimize.root_scalar(f, bracket=[0, xdata.max()])
             if opt_sol.converged:
                 root = opt_sol.root
                 use_fallback = False
@@ -793,10 +894,9 @@ def soma_via_branch_starts(sk,
             all_params.append(None)
 
         if not use_fallback:
-            base_path_ind = np.argmin(np.abs(xdata-root))
+            base_path_ind = np.argmin(np.abs(xdata - root))
         else:
-            d_to_soma_pt = np.linalg.norm(
-                sk.vertices[path_inds] - soma_pt, axis=1)
+            d_to_soma_pt = np.linalg.norm(sk.vertices[path_inds] - soma_pt, axis=1)
             base_path_ind = np.argmin(np.abs(d_to_soma_pt - fallback_radius))
 
         soma_vote = np.full(sk.n_vertices, np.nan)
@@ -818,7 +918,7 @@ def soma_via_branch_starts(sk,
     num_votes = len(soma_votes) - np.sum(np.isnan(soma_votes), axis=0)
     num_yes = np.nansum(soma_votes, axis=0)
 
-    with np.errstate(all='ignore'):
+    with np.errstate(all="ignore"):
         is_soma = (num_yes / num_votes) > 0.5
 
     last_nonsoma = []
@@ -842,9 +942,17 @@ def soma_via_branch_starts(sk,
     return np.flatnonzero(comps == root_comp), np.nanmedian(rs_long[comps == root_comp])
 
 
-def collapse_soma_skeleton(soma_verts, soma_pt, verts, edges, mesh_to_skeleton_map=None,
-                           collapse_index=None, return_filter=False, return_soma_ind=False):
-    """function to adjust skeleton result to move root to soma_pt 
+def collapse_soma_skeleton(
+    soma_verts,
+    soma_pt,
+    verts,
+    edges,
+    mesh_to_skeleton_map=None,
+    collapse_index=None,
+    return_filter=False,
+    return_soma_ind=False,
+):
+    """function to adjust skeleton result to move root to soma_pt
 
     Parameters
     ----------
@@ -878,7 +986,7 @@ def collapse_soma_skeleton(soma_verts, soma_pt, verts, edges, mesh_to_skeleton_m
     np.array
         edges, Qx2 array of skeleton edges
     (np.array)
-        new_mesh_to_skeleton_map, returned if mesh_to_skeleton_map and soma_pt passed 
+        new_mesh_to_skeleton_map, returned if mesh_to_skeleton_map and soma_pt passed
     (np.array)
         used_vertices, if return_filter this contains the indices into the passed verts which the return verts is using
     int
@@ -898,18 +1006,17 @@ def collapse_soma_skeleton(soma_verts, soma_pt, verts, edges, mesh_to_skeleton_m
         edges_m = edges.copy()
         edges_m[np.isin(edges, soma_verts)] = soma_i
 
-        simple_verts, simple_edges = utils.remove_unused_verts(
-            new_verts, edges_m)
+        simple_verts, simple_edges = utils.remove_unused_verts(new_verts, edges_m)
         good_edges = ~(simple_edges[:, 0] == simple_edges[:, 1])
 
         if mesh_to_skeleton_map is not None:
             consolidate_dict = {v: soma_i for v in soma_verts}
-            new_index_dict, _ = utils.remap_dict(
-                len(new_verts), consolidate_dict)
+            new_index_dict, _ = utils.remap_dict(len(new_verts), consolidate_dict)
             new_index_dict[-1] = -1
             mesh_to_skeleton_map[np.isnan(mesh_to_skeleton_map)] = -1
             new_mesh_to_skeleton_map = fastremap.remap(
-                mesh_to_skeleton_map, new_index_dict)
+                mesh_to_skeleton_map, new_index_dict
+            )
 
         output = [simple_verts, simple_edges[good_edges]]
         if mesh_to_skeleton_map is not None:

--- a/meshparty/utils_io.py
+++ b/meshparty/utils_io.py
@@ -1,0 +1,28 @@
+import numpy as np
+import json
+
+
+class NumpyEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(
+            obj,
+            (
+                np.int_,
+                np.intc,
+                np.intp,
+                np.int8,
+                np.int16,
+                np.int32,
+                np.int64,
+                np.uint8,
+                np.uint16,
+                np.uint32,
+                np.uint64,
+            ),
+        ):
+            return int(obj)
+        elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
+            return float(obj)
+        elif isinstance(obj, (np.ndarray,)):
+            return obj.tolist()
+        return json.JSONEncoder.default(self, obj)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ orjson
 blosc
 numba
 tables
+dataclasses

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ scikit-learn
 networkx
 multiwrapper
 cloud-volume>=1.16.0
-trimesh[easy]>=3.0.14
+trimesh>=3.0.14
+rtree
 pymeshfix>=0.12.3
 vtk
 shapely

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scikit-learn
 networkx
 multiwrapper
 cloud-volume>=1.16.0
-trimesh>=3.0.14
+trimesh[easy]>=3.0.14
 pymeshfix>=0.12.3
 vtk
 shapely

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ multiwrapper
 cloud-volume>=1.16.0
 trimesh>=3.0.14
 pymeshfix>=0.12.3
-vtk<9
+vtk
 shapely
 imageio
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ vtk<9
 shapely
 imageio
 pandas
+orjson
 blosc
 numba
 tables


### PR DESCRIPTION
This branch adds two features:
* Introduces a new format for saving annotation tables associated with meshwork objects that is based directly on json and h5py without going through pytables. This allows it to be compatible with bytesIO objects and thus cloudfiles.
* Richer skeleton metadata that holds skeletonization parameters in a structured dataclass. This accomplishes the same goal as in #70 with a bit more structure.

```python
@dataclass
class SkeletonMetadata:
    root_id: int = None
    soma_pt_x: float = None
    soma_pt_y: float = None
    soma_pt_z: float = None
    soma_radius: float = None
    collapse_soma: bool = None
    collapse_function: str = None
    invalidation_d: float = None
    smooth_vertices: bool = None
    compute_radius: bool = None
    shape_function: str = None
    smooth_iterations: int = None
    smooth_neighborhood: int = None
    smooth_r: float = None
    cc_vertex_thresh: int = None
    remove_zero_length_edges: bool = None
    collapse_params: dict = None
    timestamp: float = None
    skeleton_type: str = None

    _extra_fields = ["root_id", "timestamp", "skeleton_type"]

    def __init__(self, **kwargs):
        names = [f.name for f in fields(self)]
        for k, v in kwargs.items():
            if k in names:
                if isinstance(v, np.ndarray):
                    v = v.tolist()
                setattr(self, k, v)

    def skeletonize_kwargs(self):
        params = asdict(self)
        for k in self._extra_fields:
            params.pop(k)
        return params
```

This class will accept a dict and, for any values that match its fields, will fill them in. The `skeleton_type` string is there to provide some descriptive metadata that could be used as a tag, e.g. "pcg_skel_chunk_skeleton" to indicate source or maybe even "ais_skeleton" to indicate that this is a specific subpart of the larger cell. Users set this by providing a dict when creating a skeleton and it is set automatically when running `skeletonize_mesh`.

Considerations:
This suggests to me that pcg_skel results actually subclass Skeleton/Meshwork rather than make them directly, because there is significant extra metadata there for how to interpret the pcg_skel results via the different mechanisms to get meshes and vertex points, for example the coordinate system there can be in chunk units or nanometers. 