### PR TITLE
Allow optional pyembree installation

### DIFF
--- a/meshparty/meshwork/utils.py
+++ b/meshparty/meshwork/utils.py
@@ -338,10 +338,10 @@ def compress_mesh_data(mesh, cname="lz4"):
 
 
 def decompress_mesh_data(zvs, zfs, zes, znm, vxsc):
-    vs = np.frombuffer(blosc.decompress(zvs), dtype=np.float).reshape(-1, 3)
-    fs = np.frombuffer(blosc.decompress(zfs), dtype=np.int).reshape(-1, 3)
-    es = np.frombuffer(blosc.decompress(zes), dtype=np.int).reshape(-1, 2)
-    nm = np.frombuffer(blosc.decompress(znm), dtype=np.bool)
+    vs = np.frombuffer(blosc.decompress(zvs), dtype=float).reshape(-1, 3)
+    fs = np.frombuffer(blosc.decompress(zfs), dtype=int).reshape(-1, 3)
+    es = np.frombuffer(blosc.decompress(zes), dtype=int).reshape(-1, 2)
+    nm = np.frombuffer(blosc.decompress(znm), dtype=bool)
     return vs, fs, es, nm, vxsc
 
 

--- a/meshparty/ray_tracing.py
+++ b/meshparty/ray_tracing.py
@@ -1,6 +1,5 @@
 import trimesh.ray
 from trimesh.ray import ray_pyembree
-from trimesh.ray import ray_pyembree
 from scipy.linalg import block_diag
 import numpy as np
 import multiwrapper.multiprocessing_utils as mu

--- a/meshparty/skeletonize.py
+++ b/meshparty/skeletonize.py
@@ -519,7 +519,7 @@ def setup_root(mesh, is_soma_pt=None, soma_d=None, is_valid=None):
     if is_valid is not None:
         valid = np.copy(is_valid)
     else:
-        valid = np.ones(len(mesh.vertices), np.bool)
+        valid = np.ones(len(mesh.vertices), bool)
     assert len(valid) == mesh.vertices.shape[0]
 
     root = None
@@ -581,7 +581,7 @@ def mesh_teasar(
     # if certain vertices haven't been pre-invalidated start with just
     # the root vertex invalidated
     if valid is None:
-        valid = np.ones(len(mesh.vertices), np.bool)
+        valid = np.ones(len(mesh.vertices), bool)
         valid[root] = False
     else:
         if len(valid) != len(mesh.vertices):

--- a/meshparty/skeletonize.py
+++ b/meshparty/skeletonize.py
@@ -9,7 +9,7 @@ except:
     KDTree = spatial.cKDTree
 from tqdm import tqdm
 from meshparty.skeleton import Skeleton
-from .ray_tracing import ray_trace_distance, shape_diameter_function
+
 import fastremap
 import logging
 from . import skeleton_utils
@@ -145,6 +145,10 @@ def skeletonize_mesh(
                 soma_pt, temp_sk.vertices, temp_sk.edges, soma_radius
             )
         elif collapse_function == "branch":
+            try:
+                from .ray_tracing import ray_trace_distance, shape_diameter_function
+            except:
+                raise ImportError('Could not import pyembree for ray tracing')
 
             if shape_function == "single":
                 rs = ray_trace_distance(
@@ -217,6 +221,11 @@ def skeletonize_mesh(
 
     if compute_radius is True:
         if rs is None:
+            try:
+                from .ray_tracing import ray_trace_distance, shape_diameter_function
+            except:
+                raise ImportError('Could not import pyembree for ray tracing')
+
             if shape_function == "single":
                 rs = ray_trace_distance(orig_skel_index[vert_filter], mesh)
             elif shape_function == "cone":

--- a/meshparty/trimesh_io.py
+++ b/meshparty/trimesh_io.py
@@ -1017,7 +1017,7 @@ class Mesh(trimesh.Trimesh):
             center_node_ids = np.array([np.random.randint(len(self.vertices))])
 
         if center_coords is None:
-            center_node_ids = np.array(center_node_ids, dtype=np.int)
+            center_node_ids = np.array(center_node_ids, dtype=int)
             center_coords = self.vertices[center_node_ids]
 
         if sample_n_points is None:

--- a/meshparty/trimesh_io.py
+++ b/meshparty/trimesh_io.py
@@ -89,7 +89,7 @@ def read_mesh_h5(filename):
         link_edges, a Kx2 a,b list of extra link edges to add to the mesh graph np.int32
         None if this doesn't exist
     :obj:`np.array`
-        node_mask, a N length np.bool area of whether to mask this index (None if doesn't exist)
+        node_mask, a N length bool area of whether to mask this index (None if doesn't exist)
         None if this doesn't exist
 
     Raises
@@ -152,7 +152,7 @@ def write_mesh_h5(filename, vertices, faces,
         a Kx2 a,b list of extra link edges to add to the mesh graph np.int32
         None if this doesn't exist (default None)
     node_mask: np.array
-        a N length np.bool area of whether to mask this index (None if doesn't exist)
+        a N length bool area of whether to mask this index (None if doesn't exist)
         None if this doesn't exist (default None)
     overwrite: False
         whether to overwrite the file, will return silently if mesh file exists already
@@ -206,7 +206,7 @@ def read_mesh(filename):
         link_edges, a Kx2 a,b list of extra link edges to add to the mesh graph np.int32
         None if this doesn't exist or is an obj file
     :obj:`numpy.array`
-        node_mask, a N length np.bool area of whether to mask this index (None if doesn't exist)
+        node_mask, a N length bool area of whether to mask this index (None if doesn't exist)
         None if this doesn't exist or is an obj file
 
     """
@@ -1046,7 +1046,7 @@ class Mesh(trimesh.Trimesh):
 
                     new_dists = []
                     new_node_ids = []
-                    ids = np.arange(0, sample_n_points, dtype=np.int)
+                    ids = np.arange(0, sample_n_points, dtype=int)
                     for i_sample in range(len(center_coords)):
                         sample_ids = np.random.choice(ids, n_points,
                                                       replace=False,
@@ -1055,9 +1055,9 @@ class Mesh(trimesh.Trimesh):
                         new_node_ids.append(node_ids[i_sample, sample_ids])
 
                     dists = np.array(new_dists, dtype=np.float32)
-                    node_ids = np.array(new_node_ids, dtype=np.int)
+                    node_ids = np.array(new_node_ids, dtype=int)
                 else:
-                    ids = np.arange(0, sample_n_points, dtype=np.int)
+                    ids = np.arange(0, sample_n_points, dtype=int)
                     sample_ids = np.random.choice(ids, n_points, replace=False)
 
                     dists = dists[:, sample_ids]

--- a/meshparty/trimesh_repair.py
+++ b/meshparty/trimesh_repair.py
@@ -164,7 +164,7 @@ def find_edges_to_link(mesh, vert_ind_a, vert_ind_b, distance_upper_bound=2500, 
     # merge edge and within 2x the euclidean length of the edge
     inds = mesh.kdtree.query_ball_point(c, d*2)
     # convert this to a mask
-    mask = np.zeros(len(mesh.vertices), dtype=np.bool)
+    mask = np.zeros(len(mesh.vertices), dtype=bool)
     mask[inds] = True
 
     timings['create_mask'] = time.time()-start_time

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ h5py
 numpy
 scipy>=1.3.0
 scikit-learn
-networkx
+networkx<3
 multiwrapper
 cloud-volume>=1.16.0
 trimesh>=3.0.14

--- a/test/meshwork_test.py
+++ b/test/meshwork_test.py
@@ -50,5 +50,5 @@ def test_meshwork_skeleton(basic_meshwork):
 
     nrn.apply_mask(ds_pts.to_mesh_mask)
     new_mesh = meshwork.Meshwork(nrn.mesh)
-    new_mesh.skeletonize_mesh()
+    new_mesh.skeletonize_mesh(compute_radius=False)
     assert np.isclose(new_mesh.path_length(), 106050.47)

--- a/test/test_mesh_filters.py
+++ b/test/test_mesh_filters.py
@@ -1,7 +1,7 @@
 from meshparty import trimesh_io, mesh_filters, trimesh_vtk
 import numpy as np
 import os 
-import imageio
+import imageio.v2 as imageio
 import pytest
 
 def compare_img_to_test_file(fname, back_val = 255, close=15):

--- a/test/trimesh_vtk_test.py
+++ b/test/trimesh_vtk_test.py
@@ -3,7 +3,7 @@ import contextlib
 import numpy as np
 import pytest
 import os
-import imageio
+import imageio.v2 as imageio
 import json
 import matplotlib.cm as cm
 

--- a/test/trimesh_vtk_test.py
+++ b/test/trimesh_vtk_test.py
@@ -63,7 +63,7 @@ def eval_actor_360(actors, dir_name, tmp_path, camera=None, scale=2, nframes=30,
     if make_image:
         return True
     else:
-        is_good = np.zeros(nframes, np.bool)
+        is_good = np.zeros(nframes, bool)
         for i in range(nframes):
             img_file = os.path.join(fpath, f'%04d.png' % i)
             is_good[i] = compare_img_to_test_file(


### PR DESCRIPTION
Pyembree import is only attempted if needed, and is kept under a try/except error for cleanliness. Along the way, I fixed a few issues that were causing deprecation warnings: 1) `np.int/np.bool/np.float` are now just `int/bool/float`. 2) Imageio is going to update to v3 at some point that will change behavior, so to avoid that I switched to `import imageio.v2 as imageio` as suggested by its deprecation warning.