### PR TITLE
docs: fix "it's" to "its" in skeletons documentation

### DIFF
--- a/docs/guide/skeletons.rst
+++ b/docs/guide/skeletons.rst
@@ -26,7 +26,7 @@ There are a number of parameter options that are best understood after understan
 
 Algorithm
 ---------
-The algorithm at it's core works on a connected component of the mesh graph.
+The algorithm at its core works on a connected component of the mesh graph.
 Disconnected components are skeletonized separately, and trivially combined.
 
 For each component, first a root node is found.  A discussion of root node finding is below.

--- a/meshparty/trimesh_io.py
+++ b/meshparty/trimesh_io.py
@@ -1272,7 +1272,7 @@ class Mesh(trimesh.Trimesh):
         merge_log : dict
             JSON dict of merge log as it comes out of the chunkedgraph client. If used, must
             also set base_resolution, the mip 0 resolution of the supervoxel segmentation volume.
-        dataset_name: str or None, optional
+        datastack_name: str or None, optional
             The datastack name this mesh can be found in. If None, requires a pre-made client
             passed through the client parameter. Defaults to None.
         close_map_distance: float, optional


### PR DESCRIPTION
Fixes #107

Simple typo fix: "it's" → "its" (possessive, not contraction) in the skeletons documentation.